### PR TITLE
Adding new Cleanup type to sync package

### DIFF
--- a/concurrency/sync/pool_test.go
+++ b/concurrency/sync/pool_test.go
@@ -30,3 +30,26 @@ func TestPool(t *testing.T) {
 		},
 	)
 }
+
+func TestCleanup(t *testing.T) {
+	ctx := context.Background()
+
+	pool := NewPool[*int](ctx, "", func() *int { var x int; return &x }, WithBuffer(1))
+
+	v := NewCleanup[int](ctx, pool)
+	x := v.V()
+	*x = 1
+	v = nil
+
+	if len(pool.buffer) != 0 {
+		t.Fatalf("pool buffer not empty: %d", len(pool.buffer))
+	}
+	runtime.GC()
+	if len(pool.buffer) != 1 {
+		t.Fatalf("pool buffer empty after GC: %d", len(pool.buffer))
+	}
+	buffered := <-pool.buffer
+	if *buffered != 1 {
+		t.Fatalf("buffered value not 1: %d", *buffered)
+	}
+}

--- a/concurrency/worker/promise_test.go
+++ b/concurrency/worker/promise_test.go
@@ -30,7 +30,7 @@ func TestPromiseWithPool(t *testing.T) {
 	}{
 		{
 			name: "With pool",
-			pool: &pool,
+			pool: pool,
 		},
 		{
 			name: "Without pool",

--- a/values/generics/promises/promise_test.go
+++ b/values/generics/promises/promise_test.go
@@ -30,7 +30,7 @@ func TestPromiseWithPool(t *testing.T) {
 	}{
 		{
 			name: "With pool",
-			pool: &pool,
+			pool: pool,
 		},
 		{
 			name: "Without pool",


### PR DESCRIPTION
This does two things:

1. Changes NewPool() to return a pointer.  I think I'm just being padantic with returning a non-pointer.  I think this generally aligns better with standard use cases vs. not putting a pointer on the use case of package globals. This is not saving me from the garbage collector.

2. Uses the new go 1.24 to allow tracking an object across multiple functions and doing automatica sync.Pool.Put(). Not as efficient as doing it manually, but safer in many scenarios where it gets hard to track when something is going to release.