### PR TITLE
Adding the ability to turn on stack traces for errors and record them in logs

### DIFF
--- a/telemetry/log/log.go
+++ b/telemetry/log/log.go
@@ -19,6 +19,9 @@ var defaultLog *slog.Logger
 // that needs to log messages or you need to pass the logger to a function outside of medbay.
 // Anything other use of this logger (or any logger) is verboten.
 func Default() *slog.Logger {
+	if defaultLog == nil {
+		return slog.Default()
+	}
 	return defaultLog
 }
 


### PR DESCRIPTION
Adds an option and an attribute for getting stack traces on demand.