### PR TITLE
Fixing a 'I am a moron' type of mistake

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -7,11 +7,12 @@ package context
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	"github.com/gostdlib/base/concurrency/background"
 	"github.com/gostdlib/base/concurrency/worker"
 	internalCtx "github.com/gostdlib/base/internal/context"
+	"github.com/gostdlib/base/telemetry/log"
 	"github.com/gostdlib/base/telemetry/otel/metrics"
 
 	"go.opentelemetry.io/otel/metric"
@@ -55,12 +56,12 @@ func Attach(ctx Context) Context {
 }
 
 // Log returns the logger attached to the context. If no logger is attached, it returns log.Default().
-func Log(ctx Context) *log.Logger {
+func Log(ctx Context) *slog.Logger {
 	a := ctx.Value(loggerKey{})
 	if a == nil {
 		return log.Default()
 	}
-	l, ok := a.(*log.Logger)
+	l, ok := a.(*slog.Logger)
 	if !ok {
 		return log.Default()
 	}

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -2,10 +2,11 @@ package context
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"testing"
 
 	"github.com/gostdlib/base/concurrency/background"
+	"github.com/gostdlib/base/telemetry/log"
 	"github.com/gostdlib/base/telemetry/otel/metrics"
 
 	"go.opentelemetry.io/otel/metric"
@@ -29,7 +30,7 @@ func TestLog(t *testing.T) {
 	tests := []struct {
 		name string
 		ctx  context.Context
-		want *log.Logger
+		want *slog.Logger
 	}{
 		{
 			name: "LoggerAttached",


### PR DESCRIPTION
Was returning log.Default(), but not the one from the base "log" package.  Which means the log.Logger instead of the slog.Logger.

