### PR TITLE
Adding a priority queue based worker system onto the limited pool

### DIFF
--- a/concurrency/worker/internal/heap/heap.go
+++ b/concurrency/worker/internal/heap/heap.go
@@ -10,7 +10,7 @@
 // highest-priority item from the queue. The Examples include such an
 // implementation; the file example_pq_test.go has the complete source.
 //
-// Note: This differes from the standard library in that it implements generics.
+// Note: This differs from the standard library in that it implements generics.
 package heap
 
 import (

--- a/concurrency/worker/internal/heap/heap.go
+++ b/concurrency/worker/internal/heap/heap.go
@@ -1,0 +1,119 @@
+// Package heap provides heap operations for any type that implements
+// heap.Interface. A heap is a tree with the property that each node is the
+// minimum-valued node in its subtree.
+//
+// The minimum element in the tree is the root, at index 0.
+//
+// A heap is a common way to implement a priority queue. To build a priority
+// queue, implement the Heap interface with the (negative) priority as the
+// ordering for the Less method, so Push adds items while Pop removes the
+// highest-priority item from the queue. The Examples include such an
+// implementation; the file example_pq_test.go has the complete source.
+//
+// Note: This differes from the standard library in that it implements generics.
+package heap
+
+import (
+	"context"
+	"sort"
+)
+
+// The Interface type describes the requirements
+// for a type using the routines in this package.
+// Any type that implements it may be used as a
+// min-heap with the following invariants (established after
+// [Init] has been called or if the data is empty or sorted):
+//
+//	!h.Less(j, i) for 0 <= i < h.Len() and 2*i+1 <= j <= 2*i+2 and j < h.Len()
+//
+// Note that [Push] and [Pop] in this interface are for package heap's
+// implementation to call. To add and remove things from the heap,
+// use [heap.Push] and [heap.Pop].
+type Interface[T any] interface {
+	sort.Interface
+	Push(ctx context.Context, x T) // add x as element Len()
+	Pop(ctx context.Context) T     // remove and return element Len() - 1.
+}
+
+// Init establishes the heap invariants required by the other routines in this package.
+// Init is idempotent with respect to the heap invariants
+// and may be called whenever the heap invariants may have been invalidated.
+// The complexity is O(n) where n = h.Len().
+func Init[T any](h Interface[T]) {
+	// heapify
+	n := h.Len()
+	for i := n/2 - 1; i >= 0; i-- {
+		down(h, i, n)
+	}
+}
+
+// Push pushes the element x onto the heap.
+// The complexity is O(log n) where n = h.Len().
+func Push[T any](ctx context.Context, h Interface[T], x T) {
+	h.Push(ctx, x)
+	up(h, h.Len()-1)
+}
+
+// Pop removes and returns the minimum element (according to Less) from the heap.
+// The complexity is O(log n) where n = h.Len().
+// Pop is equivalent to [Remove](h, 0).
+func Pop[T any](ctx context.Context, h Interface[T]) T {
+	n := h.Len() - 1
+	h.Swap(0, n)
+	down(h, 0, n)
+	return h.Pop(ctx)
+}
+
+// Remove removes and returns the element at index i from the heap.
+// The complexity is O(log n) where n = h.Len().
+func Remove[T any](ctx context.Context, h Interface[T], i int) T {
+	n := h.Len() - 1
+	if n != i {
+		h.Swap(i, n)
+		if !down(h, i, n) {
+			up(h, i)
+		}
+	}
+	return h.Pop(ctx)
+}
+
+// Fix re-establishes the heap ordering after the element at index i has changed its value.
+// Changing the value of the element at index i and then calling Fix is equivalent to,
+// but less expensive than, calling [Remove](h, i) followed by a Push of the new value.
+// The complexity is O(log n) where n = h.Len().
+func Fix[T any](h Interface[T], i int) {
+	if !down(h, i, h.Len()) {
+		up(h, i)
+	}
+}
+
+func up[T any](h Interface[T], j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		j = i
+	}
+}
+
+func down[T any](h Interface[T], i0, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && h.Less(j2, j1) {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		i = j
+	}
+	return i > i0
+}

--- a/concurrency/worker/limited.go
+++ b/concurrency/worker/limited.go
@@ -74,9 +74,12 @@ type pqOpts struct{}
 // PQOption is a function that can be used to configure a PriorityQueue.
 type PQOption func(pqOpts) (pqOpts, error)
 
-// PriorityQueue provides a priority queue that can be used to submit jobs to the pool.
+// PriorityQueue provides a strict priority queue that can be used to submit jobs to the pool.
 // This will use the Limited pool to limit the number of concurrent jobs. maxSize
 // is the maximum size of the queue. A size < 1 will panic.
+// Note: In a PriorityQueue, jobs are processed in order of priority, with higher priority jobs being
+// processed first. This means that low priority jobs can stay in the queue forever as long as
+// higher priority jobs continue to enter the queue.
 func (l *Limited) PriorityQueue(maxSize int, options ...PQOption) *Queue {
 	if maxSize < 1 {
 		panic("maxSize must be greater than 0")

--- a/concurrency/worker/limited.go
+++ b/concurrency/worker/limited.go
@@ -14,8 +14,9 @@ import (
 var numCPU int
 
 func init() {
-	if runtime.GOMAXPROCS(-1) > 0 && runtime.GOMAXPROCS(-1) < runtime.NumCPU() {
-		numCPU = runtime.GOMAXPROCS(-1)
+	currentMaxProcs := runtime.GOMAXPROCS(-1)
+	if currentMaxProcs > 0 && currentMaxProcs < runtime.NumCPU() {
+		numCPU = currentMaxProcs
 		return
 	}
 	numCPU = runtime.NumCPU()
@@ -93,7 +94,7 @@ func (l *Limited) PriorityQueue(maxSize int) *Queue {
 		panic("maxSize must be greater than 0")
 	}
 	d := &Queue{
-		queue: &queue{},
+		queue: &queue{popping: make(chan struct{}, 1)},
 		done:  make(chan struct{}),
 		size:  make(chan struct{}, maxSize),
 		pool:  l,

--- a/concurrency/worker/limited.go
+++ b/concurrency/worker/limited.go
@@ -69,18 +69,13 @@ func (l *Limited) Group() bSync.Group {
 	return bSync.Group{Pool: l}
 }
 
-type pqOpts struct{}
-
-// PQOption is a function that can be used to configure a PriorityQueue.
-type PQOption func(pqOpts) (pqOpts, error)
-
 // PriorityQueue provides a strict priority queue that can be used to submit jobs to the pool.
 // This will use the Limited pool to limit the number of concurrent jobs. maxSize
 // is the maximum size of the queue. A size < 1 will panic.
 // Note: In a PriorityQueue, jobs are processed in order of priority, with higher priority jobs being
 // processed first. This means that low priority jobs can stay in the queue forever as long as
 // higher priority jobs continue to enter the queue.
-func (l *Limited) PriorityQueue(maxSize int, options ...PQOption) *Queue {
+func (l *Limited) PriorityQueue(maxSize int) *Queue {
 	if maxSize < 1 {
 		panic("maxSize must be greater than 0")
 	}

--- a/concurrency/worker/limited.go
+++ b/concurrency/worker/limited.go
@@ -69,10 +69,15 @@ func (l *Limited) Group() bSync.Group {
 	return bSync.Group{Pool: l}
 }
 
+type pqOpts struct{}
+
+// PQOption is a function that can be used to configure a PriorityQueue.
+type PQOption func(pqOpts) (pqOpts, error)
+
 // PriorityQueue provides a priority queue that can be used to submit jobs to the pool.
 // This will use the Limited pool to limit the number of concurrent jobs. maxSize
 // is the maximum size of the queue. A size < 1 will panic.
-func (l *Limited) PriorityQueue(maxSize int) *Queue {
+func (l *Limited) PriorityQueue(maxSize int, options ...PQOption) *Queue {
 	if maxSize < 1 {
 		panic("maxSize must be greater than 0")
 	}

--- a/concurrency/worker/limited.go
+++ b/concurrency/worker/limited.go
@@ -68,3 +68,24 @@ func (l *Limited) Wait() {
 func (l *Limited) Group() bSync.Group {
 	return bSync.Group{Pool: l}
 }
+
+// PriorityQueue provides a priority queue that can be used to submit jobs to the pool.
+// This will use the Limited pool to limit the number of concurrent jobs. maxSize
+// is the maximum size of the queue. A size < 1 will panic.
+func (l *Limited) PriorityQueue(maxSize int) *Queue {
+	if maxSize < 1 {
+		panic("maxSize must be greater than 0")
+	}
+	d := &Queue{
+		queue: &queue{},
+		done:  make(chan struct{}),
+		size:  make(chan struct{}, maxSize),
+		pool:  l,
+	}
+
+	Default().Submit(
+		context.Background(),
+		d.doWork,
+	)
+	return d
+}

--- a/concurrency/worker/priority.go
+++ b/concurrency/worker/priority.go
@@ -1,0 +1,168 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gostdlib/base/concurrency/worker/internal/heap"
+)
+
+// QJob represents a job to be done in a priority queue.
+type QJob struct {
+	// Priority is the job's priority.
+	Priority uint8
+	// Work is the work to be done by the job.
+	Work func()
+
+	// ctx is the context for the job.
+	ctx context.Context
+}
+
+// queue implements the heap interface. We are using a custom generic heap instead of the stdlib.
+type queue struct {
+	mu   sync.Mutex
+	jobs []QJob
+}
+
+func (p *queue) Len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return len(p.jobs)
+}
+
+func (p *queue) Less(i, j int) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.jobs[i].Priority > p.jobs[j].Priority
+}
+
+func (p *queue) Swap(i, j int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.jobs[i], p.jobs[j] = p.jobs[j], p.jobs[i]
+}
+
+func (p *queue) Push(ctx context.Context, x QJob) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.jobs = append(p.jobs, x)
+}
+
+func (p *queue) Pop(ctx context.Context) QJob {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.jobs) == 0 {
+		return QJob{}
+	}
+
+	n := len(p.jobs) - 1
+	job := p.jobs[n]
+	p.jobs = p.jobs[0:n]
+	return job
+}
+
+// Queue represents a priority queue for jobs. This can be created from a Limited Pool via Queue().
+type Queue struct {
+	queue *queue
+	done  chan struct{}
+	count atomic.Int64
+	wait  sync.WaitGroup
+	size  chan struct{}
+	pool  *Limited
+}
+
+// Close closes the queue. Be sure that the queue is empty before closing.
+func (d *Queue) Close() {
+	close(d.done)
+}
+
+// QueueLen returns the size of the queue not processed. This does not include QJobs that are
+// currently being processed.
+func (d *Queue) QueueLen() int {
+	return int(d.count.Load())
+}
+
+// Wait waits for the queue to be empty and not processing being done or the context to be canceled.
+// If the context is canceled, the context error will be returned.
+func (d *Queue) Wait(ctx context.Context) error {
+	done := make(chan struct{})
+
+	Default().Submit(
+		ctx,
+		func() {
+			for {
+				if d.QueueLen() == 0 {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			d.wait.Wait()
+			close(done)
+		},
+	)
+
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-done:
+	}
+	return nil
+}
+
+// Submit will submit a job to the queue. If the queue is full, it will block until there is room
+// in the queue or the context is canceled. A job with priority 0 will be assigned a default priority of 100.
+// Valid priority values are 1 - 254. Higher priority jobs (highest being 254) will be processed first.
+func (d *Queue) Submit(ctx context.Context, job QJob) error {
+	if job.Work == nil {
+		return errors.New("job has no work")
+	}
+	if job.Priority == 0 {
+		job.Priority = 100
+	}
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case d.size <- struct{}{}:
+	}
+
+	job.ctx = ctx
+	heap.Push(ctx, d.queue, job)
+	d.count.Add(1)
+	return nil
+}
+
+// doWork simply sends our QJobs to be done by the worker pool.
+func (d *Queue) doWork() {
+	for {
+		select {
+		case <-d.done:
+			return
+		case <-d.size:
+		}
+
+		job := heap.Pop(context.Background(), d.queue)
+		d.count.Add(-1)
+		if job.Work == nil {
+			panic("Bug: job has no work")
+		}
+
+		d.wait.Add(1)
+		f := func() {
+			defer d.wait.Done()
+			job.Work()
+		}
+
+		if err := d.pool.Submit(job.ctx, f); err != nil {
+			log.Printf("error submitting job to pool: %v", err)
+		}
+	}
+}

--- a/concurrency/worker/priority_test.go
+++ b/concurrency/worker/priority_test.go
@@ -14,7 +14,7 @@ func Test_queue(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	q := &queue{}
+	q := &queue{popping: make(chan struct{}, 1)}
 
 	// Test Push
 	job1 := QJob{Priority: 2, Work: func() {}}

--- a/concurrency/worker/priority_test.go
+++ b/concurrency/worker/priority_test.go
@@ -113,7 +113,7 @@ func TestQueueLen(t *testing.T) {
 		err := queue.Submit(
 			ctx,
 			QJob{
-				Priority: uint8(i + 1),
+				Priority: uint64(i + 1),
 				Work:     func() { time.Sleep(100 * time.Millisecond) },
 			},
 		)

--- a/concurrency/worker/priority_test.go
+++ b/concurrency/worker/priority_test.go
@@ -1,0 +1,174 @@
+package worker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gostdlib/base/concurrency/worker/internal/heap"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func Test_queue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	q := &queue{}
+
+	// Test Push
+	job1 := QJob{Priority: 2, Work: func() {}}
+	job2 := QJob{Priority: 3, Work: func() {}}
+	job3 := QJob{Priority: 1, Work: func() {}}
+	job4 := QJob{Priority: 254, Work: func() {}}
+
+	heap.Push(ctx, q, job1)
+	heap.Push(ctx, q, job2)
+	if q.Len() != 2 {
+		t.Fatalf("Test_queue: got queue length %d, want 2", q.Len())
+	}
+
+	// Test Pop: [3, 2]
+	poppedJob := heap.Pop(ctx, q)
+	if poppedJob.Priority != job2.Priority {
+		t.Fatalf("Test_queue: got priority %d, want %d", poppedJob.Priority, job2.Priority)
+	}
+	if q.Len() != 1 {
+		t.Fatalf("Test_queue: got queue length %d, want 1", q.Len())
+	}
+	heap.Push(ctx, q, job3)
+	heap.Push(ctx, q, job4)
+
+	// Test Pop: [254, 2, 1]]
+	poppedJob = heap.Pop(ctx, q)
+	if poppedJob.Priority != job4.Priority {
+		t.Fatalf("Test_queue: got priority %d, want %d", poppedJob.Priority, job4.Priority)
+	}
+	// Test Pop: [2, 1]
+	poppedJob = heap.Pop(ctx, q)
+	if poppedJob.Priority != job1.Priority {
+		t.Fatalf("Test_queue: got priority %d, want %d", poppedJob.Priority, job1.Priority)
+	}
+	if q.Len() != 1 {
+		t.Fatalf("Test_queue: got queue length %d, want 1", q.Len())
+	}
+	// Test Pop: [1]
+	poppedJob = heap.Pop(ctx, q)
+	if poppedJob.Priority != job3.Priority {
+		t.Fatalf("Test_queue: got priority %d, want %d", poppedJob.Priority, job3.Priority)
+	}
+}
+
+func TestQueueSubmitAndProcess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	queue := Default().Limited(1).PriorityQueue(10)
+	defer queue.Close()
+
+	var processed atomic.Int64
+
+	values := []int{}
+	// Submit jobs with varying priorities.
+	jobs := []QJob{
+		{Priority: 10, Work: func() { time.Sleep(1 * time.Second); processed.Add(1); values = append(values, 10) }},
+		{Priority: 50, Work: func() { processed.Add(1); values = append(values, 50) }},
+		{Priority: 200, Work: func() { processed.Add(1); values = append(values, 200) }},
+		{Priority: 100, Work: func() { processed.Add(1); values = append(values, 100) }},
+	}
+
+	for i, job := range jobs {
+		if err := queue.Submit(ctx, job); err != nil {
+			t.Fatalf("Submit failed: %v", err)
+		}
+		if i == 0 {
+			time.Sleep(10 * time.Millisecond) // Gives time for Priority 10 job to start.
+		}
+	}
+
+	// Wait for all jobs to be processed.
+	if err := queue.Wait(ctx); err != nil {
+		t.Fatalf("Queue.Wait() returned an error: %v", err)
+	}
+
+	want := []int{10, 200, 100, 50} // 10 is first because we set it up that way.
+
+	if diff := pretty.Compare(want, values); diff != "" {
+		t.Errorf("TestQueueSubmitAndProcess: -want/+got:\n%s", diff)
+	}
+	if processed.Load() != int64(len(jobs)) {
+		t.Errorf("Expected %d jobs to be processed, but got %d", len(jobs), processed.Load())
+	}
+}
+
+func TestQueueLen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	queue := Default().Limited(2).PriorityQueue(5)
+	defer queue.Close()
+
+	// Submit jobs to the queue.
+	for i := 0; i < 3; i++ {
+		err := queue.Submit(
+			ctx,
+			QJob{
+				Priority: uint8(i + 1),
+				Work:     func() { time.Sleep(100 * time.Millisecond) },
+			},
+		)
+		if err != nil {
+			t.Fatalf("Submit failed: %v", err)
+		}
+	}
+
+	if queue.QueueLen() != 3 {
+		t.Errorf("Expected queue length to be 3, but got %d", queue.QueueLen())
+	}
+
+	// Wait for all jobs to be processed.
+	if err := queue.Wait(ctx); err != nil {
+		t.Fatalf("Queue.Wait() returned an error: %v", err)
+	}
+
+	if queue.QueueLen() != 0 {
+		t.Errorf("Expected queue length to be 0 after processing, but got %d", queue.QueueLen())
+	}
+}
+
+func TestQueueClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pool := Default().Limited(2)
+	queue := pool.PriorityQueue(5)
+
+	err := queue.Submit(
+		ctx,
+		QJob{
+			Priority: 1,
+			Work:     func() { time.Sleep(10 * time.Millisecond) },
+		},
+	)
+	if err != nil {
+		t.Fatalf("Submit failed: %v", err)
+	}
+
+	queue.Close()
+
+	// After closing, submitting should fail or panic; we test that it doesn't hang.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = queue.Submit(ctx, QJob{
+			Priority: 1,
+			Work:     func() {},
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Submit after Close() hung unexpectedly")
+	}
+}


### PR DESCRIPTION
Adds a priority based worker pool option on the limited pool.

This also included a fork of the stdlib heap library, but the only changes are making it generic.

Finally, I added a test for a feature of the sync.Group object.