### PR TITLE
Adding sub pool stuff and a bunch of flaky test fixes, priority queue fixex

### DIFF
--- a/concurrency/worker/limited.go
+++ b/concurrency/worker/limited.go
@@ -90,19 +90,5 @@ func (l *Limited) Group() bSync.Group {
 // processed first. This means that low priority jobs can stay in the queue forever as long as
 // higher priority jobs continue to enter the queue.
 func (l *Limited) PriorityQueue(maxSize int) *Queue {
-	if maxSize < 1 {
-		panic("maxSize must be greater than 0")
-	}
-	d := &Queue{
-		queue: &queue{popping: make(chan struct{}, 1)},
-		done:  make(chan struct{}),
-		size:  make(chan struct{}, maxSize),
-		pool:  l,
-	}
-
-	Default().Submit(
-		context.Background(),
-		d.doWork,
-	)
-	return d
+	return newQueue(maxSize, l)
 }

--- a/concurrency/worker/limited_test.go
+++ b/concurrency/worker/limited_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,7 +13,10 @@ func TestLimited(t *testing.T) {
 
 	exit := make(chan struct{}, 1)
 	var done atomic.Int32
+	startedWG := sync.WaitGroup{}
+	startedWG.Add(4)
 	f := func() {
+		startedWG.Done()
 		<-exit
 		done.Add(1)
 	}
@@ -30,21 +34,38 @@ func TestLimited(t *testing.T) {
 	l.Submit(ctx, f)
 	l.Submit(ctx, f)
 
+	// Wait for each of these to start running.
+	startedWG.Wait()
+
 	blockedHappened := make(chan struct{})
 	go func() {
-		defer close(blockedHappened)
+		l.Submit(
+			ctx,
+			func() {
+				defer close(blockedHappened)
+			},
+		)
 	}()
 
+	// Make sure this is working like we think.
 	if done.Load() != 0 {
 		t.Fatalf("TestLimited: a function ended early")
 	}
 
+	// Give the blockHappened function time to attempt to run (it shouldn't due to limited jobs).
+	time.Sleep(100 * time.Millisecond)
+
+	// Test to make sure that didn't happen.
 	select {
 	case <-blockedHappened:
 		t.Fatalf("TestLimited: a function that should have been blocked wasn't")
 	default:
 	}
+
+	// Cause all the 1 of the waiting goroutines to run, freeing up blockHappened to be closed.
 	exit <- struct{}{}
+
+	// Wait for blockHappened to close.
 	time.Sleep(100 * time.Millisecond)
 	select {
 	case <-blockedHappened:
@@ -52,14 +73,15 @@ func TestLimited(t *testing.T) {
 		t.Fatalf("TestLimited: a blocked function should have completed")
 	}
 
+	// One of our original goroutines should be done.
 	if done.Load() != 1 {
 		t.Fatalf("TestLimited: goroutine should have finished")
 	}
 
-	for i := 0; i < 3; i++ {
-		exit <- struct{}{}
-	}
+	// Force the others to finish.
+	close(exit)
 
+	// Give time for each to finish.
 	time.Sleep(100 * time.Millisecond)
 
 	if done.Load() != 4 {

--- a/concurrency/worker/worker_test.go
+++ b/concurrency/worker/worker_test.go
@@ -3,11 +3,14 @@ package worker
 import (
 	"context"
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestPool(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	p, err := New(ctx, "myPool")
 	if err != nil {
@@ -53,5 +56,95 @@ func TestPool(t *testing.T) {
 	case <-verifyPoolGrowth:
 	default:
 		t.Fatalf("TestPool: pool did not grow as expected")
+	}
+}
+
+func TestSubPool(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p, err := New(ctx, "myPool")
+	if err != nil {
+		panic(err)
+	}
+
+	sub1 := p.Sub(ctx, "subPool1")
+	sub2 := sub1.Sub(ctx, "subPool2")
+
+	answer := make([]bool, 1000)
+	for i := 0; i < 1000; i++ {
+		if i%3 == 0 {
+			p.Submit(
+				ctx,
+				func() {
+					answer[i] = true
+					time.Sleep(100 * time.Millisecond)
+				},
+			)
+		} else if i%3 == 1 {
+			sub1.Submit(
+				ctx,
+				func() {
+					answer[i] = true
+					time.Sleep(100 * time.Millisecond)
+				},
+			)
+		} else {
+			sub2.Submit(
+				ctx,
+				func() {
+					answer[i] = true
+					time.Sleep(100 * time.Millisecond)
+				},
+			)
+		}
+	}
+
+	p.Wait()
+	sub1.Wait()
+	sub2.Wait()
+
+	time.Sleep(2 * time.Second) // Wait for extra goroutines to timeout.
+
+	for i, e := range answer {
+		if !e {
+			t.Fatalf("TestSubPool: entry(%d) was not set to true as expected", i)
+		}
+	}
+
+	if p.GoRoutines() != sub1.GoRoutines() {
+		t.Fatalf("TestSubPool: pool and sub1 did not have the same number of goroutines")
+	}
+
+	if p.GoRoutines() != sub2.GoRoutines() {
+		t.Fatalf("TestSubPool: pool and sub2 did not have the same number of goroutines")
+	}
+
+	if p.StaticPool() != sub1.StaticPool() {
+		t.Fatal("TestSubPool: pool and sub1 did not have the same number of static pool goroutines")
+	}
+	if p.StaticPool() != sub2.StaticPool() {
+		t.Fatal("TestSubPool: pool and sub2 did not have the same number of static pool goroutines")
+	}
+
+	sub2.Close(ctx)
+
+	at := atomic.Int64{}
+	sub1.Submit(
+		ctx,
+		func() {
+			at.Add(1)
+		},
+	)
+	p.Submit(
+		ctx,
+		func() {
+			at.Add(1)
+		},
+	)
+	sub1.Wait()
+	p.Wait()
+	if at.Load() != 2 {
+		t.Fatal("TestSubPool: closing sub2 did something bad")
 	}
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -274,6 +274,8 @@ func (f fakeSpan) SpanContext() otelTrace.SpanContext {
 }
 
 func TestStackTrace(t *testing.T) {
+	// Do not do t.Parallel().
+
 	tests := []struct {
 		name      string
 		withTrace bool


### PR DESCRIPTION
- Needed a way to make sub pools off of another pool.  This gives independent tracking and metrics while being attached to the parent pool.
- Fixed the background errors logging and enhanced logging in that package. There is another PR that this replaces currently pending.
- Fixed a bunch of test problems that were related to flakiness or some things that were stupid on my part.
- The priority queue had some problems that were flakey.  Fixed those problems and verified by running under race 100s of times.
- The background.Task has a test that would fail due to closing it. I moved background to using a sub pool off of the default pool. This also fixes that issues.