### PR TITLE
noisy log test

### DIFF
--- a/telemetry/otel/metrics/metrics_test.go
+++ b/telemetry/otel/metrics/metrics_test.go
@@ -168,7 +168,7 @@ func TestIniterServeWithOtherProvider(t *testing.T) {
 	// Check that we don't see the "reader is not registered" log
 	logOutput := logBuf.String()
 	if strings.Contains(logOutput, "reader is not registered") {
-		t.Errorf("TestIniterServeWithOtherProvider: expected to see 'reader is not registered' log, but got: %s", logOutput)
+		t.Errorf("TestIniterServeWithOtherProvider: unexpected 'reader is not registered' log: %s", logOutput)
 	}
 }
 


### PR DESCRIPTION
This test would fail if I undid the changes from my last PR.
```
➜  base ✗ go test ./telemetry/otel/metrics/... -v  -run TestIniterServeWithOtherProvider

=== RUN   TestIniterServeWithOtherProvider
{"time":"2025-08-01T09:15:33.39353-07:00","level":"INFO","source":{"function":"github.com/gostdlib/base/telemetry/otel/metrics.serveMetrics","file":"/go/src/github.io/shanalily/base/telemetry/otel/metrics/metrics.go","line":171},"msg":"serving metrics at :57761/metrics"}
    metrics_test.go:171: TestIniterServeWithOtherProvider: unexpected 'reader is not registered' log: 2025/08/01 09:15:34 reader is not registered
--- FAIL: TestIniterServeWithOtherProvider (1.01s)
FAIL
FAIL    github.com/gostdlib/base/telemetry/otel/metrics 1.358s
FAIL
```