### PR TITLE
Adding debugstrip utility and adding MethodName() to statemachine

### DIFF
--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -492,3 +492,18 @@ func methodName(method any) string {
 		return "<not a function>"
 	}
 }
+
+// MethodName takes a function or a method and returns its name. This is useful in testing
+// to determine the name of the next state in a state machine and do a comparison.
+func MethodName(method any) string {
+	if method == nil {
+		return "<nil>"
+	}
+	valueOf := reflect.ValueOf(method)
+	switch valueOf.Kind() {
+	case reflect.Func:
+		return strings.TrimSuffix(strings.TrimSuffix(runtime.FuncForPC(valueOf.Pointer()).Name(), "-fm"), "[...]")
+	default:
+		return "<not a function>"
+	}
+}

--- a/telemetry/log/utils/debugstrip/debugstrip.go
+++ b/telemetry/log/utils/debugstrip/debugstrip.go
@@ -1,0 +1,162 @@
+//go:build unix
+
+// Package debugstrip provides a utility to reformat JSON log lines into a more human-readable format.
+// This is useful when not using a structured log viewer, such as when you want to quickly scan logs in a terminal.
+// It reads from standard input and writes to standard output. Lines that are not valid JSON or do not
+// contain the expected fields are passed through unchanged.
+package debugstrip
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/go-json-experiment/json"
+	"github.com/gostdlib/base/concurrency/sync"
+)
+
+func main() {
+	scan(context.Background(), os.Stdin, os.Stdout)
+}
+
+var lineReturn = []byte{'\n'}
+
+// scan reads lines from the input reader, reformats them if they are JSON log lines, and writes them to the output writer.
+func scan(ctx context.Context, in io.Reader, out io.Writer) {
+	// Create a new scanner to read from os.Stdin
+	scanner := bufio.NewScanner(in)
+
+	for {
+		// Scan for the next token, which by default is a line
+		if scanner.Scan() {
+			// Get the text of the scanned line
+			line := scanner.Bytes()
+			_, err := out.Write(reframe(ctx, line))
+			if err != nil {
+				return
+			}
+			_, _ = out.Write(lineReturn) // Ignore this error.
+			continue
+		}
+		return
+	}
+}
+
+var reqKeys = []string{
+	"time",
+	"level",
+	"file",
+	"line",
+	"msg",
+}
+
+type mapHolder struct {
+	m map[string]any
+}
+
+func (m mapHolder) valid() bool {
+	for _, k := range reqKeys {
+		if _, ok := m.m[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (m mapHolder) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.m)
+}
+
+func (m mapHolder) Reset() {
+	clear(m.m)
+}
+
+func (m mapHolder) level() string {
+	v, ok := m.m["level"].(string)
+	if !ok {
+		return "UnknownLevel"
+	}
+	return strings.ToUpper(v)
+}
+
+func (m mapHolder) line() int {
+	switch v := m.m["line"].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}
+
+func (m mapHolder) shortFile() string {
+	v, ok := m.m["file"].(string)
+	if !ok {
+		return "unknown"
+	}
+	parts := strings.Split(v, "/")
+	if len(parts) == 0 {
+		return v
+	}
+	return parts[len(parts)-1]
+}
+
+func (m mapHolder) hourMinuteSecond() string {
+	v, ok := m.m["time"].(string)
+	if !ok {
+		return "00:00:00"
+	}
+	tm, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return "00:00:00"
+	}
+	return tm.Format(`15:04:05`)
+}
+
+func (m mapHolder) msg() string {
+	s, ok := m.m["msg"].(string)
+	if !ok {
+		return "no message"
+	}
+	return s
+}
+
+var pool = sync.NewPool(
+	context.Background(),
+	"mapHolder",
+	func() mapHolder {
+		return mapHolder{m: make(map[string]any)}
+	},
+	sync.WithBuffer(10),
+)
+
+// reframe looks for a JSON log line that it understands and reformats it to a shorter form.
+func reframe(ctx context.Context, line []byte) []byte {
+	holder := pool.Get(ctx)
+	defer pool.Put(ctx, holder)
+
+	if err := json.Unmarshal(line, &holder.m); err != nil {
+		return line
+	}
+
+	if !holder.valid() {
+		return line
+	}
+
+	// Original line:
+	//{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR","source":{"function":"path/to/package.(*Type).read","file":"/file/on/the/filesystem/it/was/created/on/checker.go","line":110},"msg":"failed to read configuration file: Internal error occurred: test error"}
+
+	// Reformatted line:
+	//[INFO][18:23:06][.../checker.go:110]: failed to read configuration file: Internal error occurred: test error
+	return strToBytes(fmt.Sprintf("[%s][%s][.../%s:%d]: %s", holder.level(), holder.hourMinuteSecond(), holder.shortFile(), holder.line(), holder.msg()))
+}
+
+func strToBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/telemetry/log/utils/debugstrip/debugstrip_test.go
+++ b/telemetry/log/utils/debugstrip/debugstrip_test.go
@@ -1,0 +1,601 @@
+package debugstrip
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestMapHolderValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want bool
+	}{
+		{
+			name: "Success: all required keys present",
+			m: map[string]any{
+				"time":  "2025-09-09T18:23:06.102045-07:00",
+				"level": "ERROR",
+				"file":  "/path/to/file.go",
+				"line":  110,
+				"msg":   "test message",
+			},
+			want: true,
+		},
+		{
+			name: "Error: missing time key",
+			m: map[string]any{
+				"level": "ERROR",
+				"file":  "/path/to/file.go",
+				"line":  110,
+				"msg":   "test message",
+			},
+			want: false,
+		},
+		{
+			name: "Error: missing level key",
+			m: map[string]any{
+				"time": "2025-09-09T18:23:06.102045-07:00",
+				"file": "/path/to/file.go",
+				"line": 110,
+				"msg":  "test message",
+			},
+			want: false,
+		},
+		{
+			name: "Error: missing file key",
+			m: map[string]any{
+				"time":  "2025-09-09T18:23:06.102045-07:00",
+				"level": "ERROR",
+				"line":  110,
+				"msg":   "test message",
+			},
+			want: false,
+		},
+		{
+			name: "Error: missing line key",
+			m: map[string]any{
+				"time":  "2025-09-09T18:23:06.102045-07:00",
+				"level": "ERROR",
+				"file":  "/path/to/file.go",
+				"msg":   "test message",
+			},
+			want: false,
+		},
+		{
+			name: "Error: missing msg key",
+			m: map[string]any{
+				"time":  "2025-09-09T18:23:06.102045-07:00",
+				"level": "ERROR",
+				"file":  "/path/to/file.go",
+				"line":  110,
+			},
+			want: false,
+		},
+		{
+			name: "Error: empty map",
+			m:    map[string]any{},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		got := holder.valid()
+		if got != test.want {
+			t.Errorf("TestMapHolderValid(%s): got %v, want %v", test.name, got, test.want)
+		}
+
+	}
+}
+
+func TestMapHolderLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want string
+	}{
+		{
+			name: "Success: valid string level",
+			m:    map[string]any{"level": "error"},
+			want: "ERROR",
+		},
+		{
+			name: "Success: another valid string level",
+			m:    map[string]any{"level": "info"},
+			want: "INFO",
+		},
+		{
+			name: "Success: debug level",
+			m:    map[string]any{"level": "debug"},
+			want: "DEBUG",
+		},
+		{
+			name: "Error: non-string level",
+			m:    map[string]any{"level": 123},
+			want: "UnknownLevel",
+		},
+		{
+			name: "Error: missing level key",
+			m:    map[string]any{},
+			want: "UnknownLevel",
+		},
+		{
+			name: "Error: nil level value",
+			m:    map[string]any{"level": nil},
+			want: "UnknownLevel",
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		got := holder.level()
+		if got != test.want {
+			t.Errorf("TestMapHolderLevel(%s): got %s, want %s", test.name, got, test.want)
+		}
+	}
+}
+
+func TestMapHolderLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want int
+	}{
+		{
+			name: "Success: valid line number",
+			m:    map[string]any{"line": 110},
+			want: 110,
+		},
+		{
+			name: "Success: zero line number",
+			m:    map[string]any{"line": 0},
+			want: 0,
+		},
+		{
+			name: "Success: large line number",
+			m:    map[string]any{"line": 99999},
+			want: 99999,
+		},
+		{
+			name: "Error: non-int line",
+			m:    map[string]any{"line": "110"},
+			want: 0,
+		},
+		{
+			name: "Error: missing line key",
+			m:    map[string]any{},
+			want: 0,
+		},
+		{
+			name: "Error: nil line value",
+			m:    map[string]any{"line": nil},
+			want: 0,
+		},
+		{
+			name: "Success: float line value gets converted to int",
+			m:    map[string]any{"line": 110.0},
+			want: 110,
+		},
+		{
+			name: "Success: float line value with fractional part gets truncated",
+			m:    map[string]any{"line": 110.7},
+			want: 110,
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		got := holder.line()
+		if got != test.want {
+			t.Errorf("TestMapHolderLine(%s): got %d, want %d", test.name, got, test.want)
+		}
+	}
+}
+
+func TestMapHolderShortFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want string
+	}{
+		{
+			name: "Success: full path with multiple directories",
+			m:    map[string]any{"file": "/path/to/very/long/directory/structure/file.go"},
+			want: "file.go",
+		},
+		{
+			name: "Success: simple path",
+			m:    map[string]any{"file": "/path/file.go"},
+			want: "file.go",
+		},
+		{
+			name: "Success: no directory separators",
+			m:    map[string]any{"file": "file.go"},
+			want: "file.go",
+		},
+		{
+			name: "Success: relative path",
+			m:    map[string]any{"file": "./dir/file.go"},
+			want: "file.go",
+		},
+		{
+			name: "Error: non-string file",
+			m:    map[string]any{"file": 123},
+			want: "unknown",
+		},
+		{
+			name: "Error: missing file key",
+			m:    map[string]any{},
+			want: "unknown",
+		},
+		{
+			name: "Error: nil file value",
+			m:    map[string]any{"file": nil},
+			want: "unknown",
+		},
+		{
+			name: "Success: empty string file",
+			m:    map[string]any{"file": ""},
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		got := holder.shortFile()
+		if got != test.want {
+			t.Errorf("TestMapHolderShortFile(%s): got %s, want %s", test.name, got, test.want)
+		}
+	}
+}
+
+func TestMapHolderHourMinuteSecond(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want string
+	}{
+		{
+			name: "Success: valid RFC3339 timestamp",
+			m:    map[string]any{"time": "2025-09-09T18:23:06.102045-07:00"},
+			want: "18:23:06",
+		},
+		{
+			name: "Success: UTC timestamp",
+			m:    map[string]any{"time": "2025-09-09T18:23:06Z"},
+			want: "18:23:06",
+		},
+		{
+			name: "Success: different timezone",
+			m:    map[string]any{"time": "2025-09-09T15:30:45+03:00"},
+			want: "15:30:45",
+		},
+		{
+			name: "Success: midnight",
+			m:    map[string]any{"time": "2025-09-09T00:00:00Z"},
+			want: "00:00:00",
+		},
+		{
+			name: "Error: invalid time format",
+			m:    map[string]any{"time": "2025-09-09 18:23:06"},
+			want: "00:00:00",
+		},
+		{
+			name: "Error: non-string time",
+			m:    map[string]any{"time": 1234567890},
+			want: "00:00:00",
+		},
+		{
+			name: "Error: missing time key",
+			m:    map[string]any{},
+			want: "00:00:00",
+		},
+		{
+			name: "Error: nil time value",
+			m:    map[string]any{"time": nil},
+			want: "00:00:00",
+		},
+		{
+			name: "Error: empty string time",
+			m:    map[string]any{"time": ""},
+			want: "00:00:00",
+		},
+		{
+			name: "Error: completely invalid time string",
+			m:    map[string]any{"time": "not a time"},
+			want: "00:00:00",
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		got := holder.hourMinuteSecond()
+		if got != test.want {
+			t.Errorf("TestMapHolderHourMinuteSecond(%s): got %s, want %s", test.name, got, test.want)
+		}
+	}
+}
+
+func TestMapHolderMsg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		want string
+	}{
+		{
+			name: "Success: valid string message",
+			m:    map[string]any{"msg": "test message"},
+			want: "test message",
+		},
+		{
+			name: "Success: empty string message",
+			m:    map[string]any{"msg": ""},
+			want: "",
+		},
+		{
+			name: "Error: non-string message",
+			m:    map[string]any{"msg": 123},
+			want: "no message",
+		},
+		{
+			name: "Error: missing msg key",
+			m:    map[string]any{},
+			want: "no message",
+		},
+		{
+			name: "Error: nil msg value",
+			m:    map[string]any{"msg": nil},
+			want: "no message",
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		got := holder.msg()
+		if got != test.want {
+			t.Errorf("TestMapHolderMsg(%s): got %s, want %s", test.name, got, test.want)
+		}
+	}
+}
+
+func TestReframe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line []byte
+		want []byte
+	}{
+		{
+			name: "Success: valid JSON log line",
+			line: []byte(`{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR","file":"/path/to/checker.go","line":110,"msg":"failed to read configuration file"}`),
+			want: []byte("[ERROR][18:23:06][.../checker.go:110]: failed to read configuration file"),
+		},
+		{
+			name: "Success: different level and time",
+			line: []byte(`{"time":"2025-09-09T15:30:45Z","level":"info","file":"/some/other/file.go","line":25,"msg":"processing request"}`),
+			want: []byte("[INFO][15:30:45][.../file.go:25]: processing request"),
+		},
+		{
+			name: "Success: debug level",
+			line: []byte(`{"time":"2025-09-09T09:15:30.123Z","level":"debug","file":"/debug/test.go","line":1,"msg":"debug message"}`),
+			want: []byte("[DEBUG][09:15:30][.../test.go:1]: debug message"),
+		},
+		{
+			name: "Error: invalid JSON returns original",
+			line: []byte(`not valid json`),
+			want: []byte(`not valid json`),
+		},
+		{
+			name: "Error: missing required fields returns original",
+			line: []byte(`{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR"}`),
+			want: []byte(`{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR"}`),
+		},
+		{
+			name: "Error: empty JSON object returns original",
+			line: []byte(`{}`),
+			want: []byte(`{}`),
+		},
+		{
+			name: "Error: valid JSON but wrong structure returns original",
+			line: []byte(`{"foo": "bar", "baz": 123}`),
+			want: []byte(`{"foo": "bar", "baz": 123}`),
+		},
+		{
+			name: "Error: empty line returns original",
+			line: []byte(``),
+			want: []byte(``),
+		},
+		{
+			name: "Success: extra fields are ignored",
+			line: []byte(`{"time":"2025-09-09T12:00:00Z","level":"warn","file":"/test.go","line":42,"msg":"warning","extra":"ignored","source":{"function":"test"}}`),
+			want: []byte("[WARN][12:00:00][.../test.go:42]: warning"),
+		},
+	}
+
+	for _, test := range tests {
+		got := reframe(t.Context(), test.line)
+		if diff := pretty.Compare(got, test.want); diff != "" {
+			t.Errorf("TestReframe(%s): -got +want:\n%s", test.name, diff)
+		}
+	}
+}
+
+func TestMapHolderReset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+	}{
+		{
+			name: "Success: reset map with data",
+			m: map[string]any{
+				"time":  "2025-09-09T18:23:06.102045-07:00",
+				"level": "ERROR",
+				"file":  "/path/to/file.go",
+				"line":  110,
+				"msg":   "test message",
+			},
+		},
+		{
+			name: "Success: reset empty map",
+			m:    map[string]any{},
+		},
+	}
+
+	for _, test := range tests {
+		holder := mapHolder{m: test.m}
+		holder.Reset()
+		if len(holder.m) != 0 {
+			t.Errorf("TestMapHolderReset(%s): expected empty map after reset, got %d items", test.name, len(holder.m))
+		}
+	}
+}
+
+func TestMapHolderMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		m       map[string]any
+		wantErr bool
+	}{
+		{
+			name: "Success: marshal simple map",
+			m: map[string]any{
+				"level": "ERROR",
+				"msg":   "test message",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Success: marshal empty map",
+			m:       map[string]any{},
+			wantErr: false,
+		},
+		{
+			name: "Success: marshal complex map",
+			m: map[string]any{
+				"time":  "2025-09-09T18:23:06.102045-07:00",
+				"level": "ERROR",
+				"file":  "/path/to/file.go",
+				"line":  110,
+				"msg":   "test message",
+				"extra": map[string]any{"nested": "value"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+
+		holder := mapHolder{m: test.m}
+		_, err := holder.MarshalJSON()
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestMapHolderMarshalJSON(%s): got err == nil, want err != nil", test.name)
+			return
+		case err != nil && !test.wantErr:
+			t.Errorf("TestMapHolderMarshalJSON(%s): got err == %s, want err == nil", test.name, err)
+			return
+		case err != nil:
+			return
+		}
+	}
+}
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "Success: single valid JSON log line",
+			input: `{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR","file":"/path/to/checker.go","line":110,"msg":"failed to read configuration file"}
+`,
+			want: "[ERROR][18:23:06][.../checker.go:110]: failed to read configuration file\n",
+		},
+		{
+			name: "Success: multiple valid JSON log lines",
+			input: `{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR","file":"/path/to/checker.go","line":110,"msg":"failed to read configuration file"}
+{"time":"2025-09-09T15:30:45Z","level":"info","file":"/some/other/file.go","line":25,"msg":"processing request"}
+`,
+			want: "[ERROR][18:23:06][.../checker.go:110]: failed to read configuration file\n[INFO][15:30:45][.../file.go:25]: processing request\n",
+		},
+		{
+			name: "Success: mix of valid and invalid lines",
+			input: `{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR","file":"/path/to/checker.go","line":110,"msg":"failed to read configuration file"}
+not valid json line
+{"time":"2025-09-09T15:30:45Z","level":"info","file":"/some/other/file.go","line":25,"msg":"processing request"}
+`,
+			want: "[ERROR][18:23:06][.../checker.go:110]: failed to read configuration file\nnot valid json line\n[INFO][15:30:45][.../file.go:25]: processing request\n",
+		},
+		{
+			name: "Success: only invalid lines pass through unchanged",
+			input: `not valid json line
+another invalid line
+yet another line
+`,
+			want: "not valid json line\nanother invalid line\nyet another line\n",
+		},
+		{
+			name:  "Success: empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name: "Success: lines missing required fields pass through unchanged",
+			input: `{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR"}
+{"foo": "bar", "baz": 123}
+`,
+			want: `{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR"}
+{"foo": "bar", "baz": 123}
+`,
+		},
+		{
+			name:  "Success: single line without newline",
+			input: `{"time":"2025-09-09T18:23:06.102045-07:00","level":"ERROR","file":"/path/to/checker.go","line":110,"msg":"test"}`,
+			want:  "[ERROR][18:23:06][.../checker.go:110]: test\n",
+		},
+		{
+			name: "Success: different log levels",
+			input: `{"time":"2025-09-09T12:00:00Z","level":"debug","file":"/test.go","line":1,"msg":"debug message"}
+{"time":"2025-09-09T12:01:00Z","level":"warn","file":"/test.go","line":2,"msg":"warning message"}
+{"time":"2025-09-09T12:02:00Z","level":"error","file":"/test.go","line":3,"msg":"error message"}
+`,
+			want: "[DEBUG][12:00:00][.../test.go:1]: debug message\n[WARN][12:01:00][.../test.go:2]: warning message\n[ERROR][12:02:00][.../test.go:3]: error message\n",
+		},
+	}
+
+	for _, test := range tests {
+		input := strings.NewReader(test.input)
+		var output bytes.Buffer
+
+		scan(t.Context(), input, &output)
+
+		got := output.String()
+		if got != test.want {
+			t.Errorf("TestScan(%s): got %q, want %q", test.name, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
the debugstrip utility allows you to pipe stdout/stderr to it and it will reformat log output from our logger to be more readable in a terminal.