### PR TITLE
Upgrading the debugstrip to handle multiple different outputs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,5 @@ jobs:
 
       - name: Test
         run: go test -v -timeout 20m ./...
-
-      - name: golang-govulncheck-action
-        uses: golang/govulncheck-action@v1.0.4
+#      - name: golang-govulncheck-action
+#        uses: golang/govulncheck-action@v1.0.4

--- a/concurrency/sync/pool_test.go
+++ b/concurrency/sync/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/tidwall/lotsa"
 )
@@ -45,6 +46,7 @@ func TestCleanup(t *testing.T) {
 		t.Fatalf("pool buffer not empty: %d", len(pool.buffer))
 	}
 	runtime.GC()
+	time.Sleep(10 * time.Millisecond)
 	if len(pool.buffer) != 1 {
 		t.Fatalf("pool buffer empty after GC: %d", len(pool.buffer))
 	}


### PR DESCRIPTION
Debugstrip is now smarter.
govulcheck is disabled due to bug[in gotypes]: https://github.com/golang/go/issues/73871
Fixed a test that started failing probably due to upstream changes.  Just needed a tiny sleep.