### PR TITLE
Custom logger [Breaking change]

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -274,7 +274,11 @@ func Tasks(ctx Context) *background.Tasks {
 // AddAttrs adds slog.Attr attributes to the context. These attributes can be used by logging,
 // tracing or errors packages to add additional context to logs, traces or errors. Duplicate attr
 // keys are allowed, but upper layer packages will apply the last value for a given key.
+// If ctx is nil, it will be set to context.Background().
 func AddAttrs(ctx context.Context, attrs ...slog.Attr) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	a := ctx.Value(attrsKey{})
 	if a == nil {
 		ctx = context.WithValue(ctx, attrsKey{}, attrs)
@@ -288,6 +292,9 @@ func AddAttrs(ctx context.Context, attrs ...slog.Attr) context.Context {
 
 // Attrs returns the slog.Attr attributes attached to the context. If no attributes are attached, it returns nil.
 func Attrs(ctx context.Context) []slog.Attr {
+	if ctx == nil {
+		return nil
+	}
 	a := ctx.Value(attrsKey{})
 	if a == nil {
 		return nil

--- a/context/context.go
+++ b/context/context.go
@@ -59,7 +59,7 @@ func Attach(ctx Context) Context {
 	return ctx
 }
 
-// Logger is a wrapper around an *slog.Logger that allo
+// Logger is a wrapper around an *slog.Logger that prevents loss of Context logging attributes.
 type Logger struct {
 	logger *slog.Logger
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -30,7 +30,7 @@ func TestLog(t *testing.T) {
 	tests := []struct {
 		name string
 		ctx  context.Context
-		want *slog.Logger
+		want Logger
 	}{
 		{
 			name: "LoggerAttached",
@@ -38,12 +38,12 @@ func TestLog(t *testing.T) {
 				ctx := context.Background()
 				return context.WithValue(ctx, loggerKey{}, defaultLogger)
 			}(),
-			want: defaultLogger,
+			want: Logger{defaultLogger},
 		},
 		{
 			name: "NoLoggerAttached",
 			ctx:  context.Background(),
-			want: defaultLogger,
+			want: Logger{defaultLogger},
 		},
 		{
 			name: "InvalidLoggerType",
@@ -51,7 +51,7 @@ func TestLog(t *testing.T) {
 				ctx := context.Background()
 				return context.WithValue(ctx, loggerKey{}, "invalid")
 			}(),
-			want: defaultLogger,
+			want: Logger{defaultLogger},
 		},
 	}
 
@@ -198,6 +198,185 @@ func TestAttrs(t *testing.T) {
 		for i := range got {
 			if !got[i].Equal(test.wantAttrs[i]) {
 				t.Errorf("TestAttrs(%s): attr[%d] = %v, want %v", test.name, i, got[i], test.wantAttrs[i])
+			}
+		}
+	}
+}
+
+// fakeHandler is a slog.Handler that captures log records for testing.
+type fakeHandler struct {
+	records []slog.Record
+	enabled bool
+}
+
+func (h *fakeHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return h.enabled
+}
+
+func (h *fakeHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *fakeHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *fakeHandler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+// recordAttrs extracts all attributes from a slog.Record into a slice.
+func recordAttrs(r slog.Record) []slog.Attr {
+	var attrs []slog.Attr
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a)
+		return true
+	})
+	return attrs
+}
+
+func TestLoggerLogContextAttrs(t *testing.T) {
+	tests := []struct {
+		name          string
+		ctxAttrs      []slog.Attr
+		logArgs       []any
+		wantAttrCount int
+		wantAttrs     map[string]any
+	}{
+		{
+			name:          "Success: context attrs are included in log output",
+			ctxAttrs:      []slog.Attr{slog.String("request_id", "abc123"), slog.Int("user_id", 42)},
+			logArgs:       []any{},
+			wantAttrCount: 2,
+			wantAttrs:     map[string]any{"request_id": "abc123", "user_id": int64(42)},
+		},
+		{
+			name:          "Success: context attrs combined with log args",
+			ctxAttrs:      []slog.Attr{slog.String("trace_id", "xyz789")},
+			logArgs:       []any{"operation", "test"},
+			wantAttrCount: 2,
+			wantAttrs:     map[string]any{"trace_id": "xyz789", "operation": "test"},
+		},
+		{
+			name:          "Success: no context attrs with log args only",
+			ctxAttrs:      nil,
+			logArgs:       []any{"key", "value"},
+			wantAttrCount: 1,
+			wantAttrs:     map[string]any{"key": "value"},
+		},
+		{
+			name:          "Success: empty context and no log args",
+			ctxAttrs:      nil,
+			logArgs:       []any{},
+			wantAttrCount: 0,
+			wantAttrs:     map[string]any{},
+		},
+	}
+
+	for _, test := range tests {
+		handler := &fakeHandler{enabled: true}
+		logger := Logger{logger: slog.New(handler)}
+
+		ctx := context.Background()
+		if len(test.ctxAttrs) > 0 {
+			ctx = AddAttrs(ctx, test.ctxAttrs...)
+		}
+
+		logger.log(ctx, slog.LevelInfo, "test message", test.logArgs...)
+
+		if len(handler.records) != 1 {
+			t.Errorf("TestLoggerLogContextAttrs(%s): got %d records, want 1", test.name, len(handler.records))
+			continue
+		}
+
+		attrs := recordAttrs(handler.records[0])
+		if len(attrs) != test.wantAttrCount {
+			t.Errorf("TestLoggerLogContextAttrs(%s): got %d attrs, want %d", test.name, len(attrs), test.wantAttrCount)
+			continue
+		}
+
+		for _, attr := range attrs {
+			want, ok := test.wantAttrs[attr.Key]
+			if !ok {
+				t.Errorf("TestLoggerLogContextAttrs(%s): unexpected attr key %q", test.name, attr.Key)
+				continue
+			}
+			if attr.Value.Any() != want {
+				t.Errorf("TestLoggerLogContextAttrs(%s): attr %q = %v, want %v", test.name, attr.Key, attr.Value.Any(), want)
+			}
+		}
+	}
+}
+
+func TestLoggerLogAttrsContextAttrs(t *testing.T) {
+	tests := []struct {
+		name          string
+		ctxAttrs      []slog.Attr
+		logAttrs      []slog.Attr
+		wantAttrCount int
+		wantAttrs     map[string]any
+	}{
+		{
+			name:          "Success: context attrs are included in logAttrs output",
+			ctxAttrs:      []slog.Attr{slog.String("request_id", "abc123"), slog.Int("user_id", 42)},
+			logAttrs:      []slog.Attr{},
+			wantAttrCount: 2,
+			wantAttrs:     map[string]any{"request_id": "abc123", "user_id": int64(42)},
+		},
+		{
+			name:          "Success: context attrs combined with passed attrs",
+			ctxAttrs:      []slog.Attr{slog.String("trace_id", "xyz789")},
+			logAttrs:      []slog.Attr{slog.String("operation", "test")},
+			wantAttrCount: 2,
+			wantAttrs:     map[string]any{"trace_id": "xyz789", "operation": "test"},
+		},
+		{
+			name:          "Success: no context attrs with passed attrs only",
+			ctxAttrs:      nil,
+			logAttrs:      []slog.Attr{slog.String("key", "value")},
+			wantAttrCount: 1,
+			wantAttrs:     map[string]any{"key": "value"},
+		},
+		{
+			name:          "Success: empty context and no passed attrs",
+			ctxAttrs:      nil,
+			logAttrs:      []slog.Attr{},
+			wantAttrCount: 0,
+			wantAttrs:     map[string]any{},
+		},
+	}
+
+	for _, test := range tests {
+		handler := &fakeHandler{enabled: true}
+		logger := Logger{logger: slog.New(handler)}
+
+		ctx := context.Background()
+		if len(test.ctxAttrs) > 0 {
+			ctx = AddAttrs(ctx, test.ctxAttrs...)
+		}
+
+		logger.logAttrs(ctx, slog.LevelInfo, "test message", test.logAttrs...)
+
+		if len(handler.records) != 1 {
+			t.Errorf("TestLoggerLogAttrsContextAttrs(%s): got %d records, want 1", test.name, len(handler.records))
+			continue
+		}
+
+		attrs := recordAttrs(handler.records[0])
+		if len(attrs) != test.wantAttrCount {
+			t.Errorf("TestLoggerLogAttrsContextAttrs(%s): got %d attrs, want %d", test.name, len(attrs), test.wantAttrCount)
+			continue
+		}
+
+		for _, attr := range attrs {
+			want, ok := test.wantAttrs[attr.Key]
+			if !ok {
+				t.Errorf("TestLoggerLogAttrsContextAttrs(%s): unexpected attr key %q", test.name, attr.Key)
+				continue
+			}
+			if attr.Value.Any() != want {
+				t.Errorf("TestLoggerLogAttrsContextAttrs(%s): attr %q = %v, want %v", test.name, attr.Key, attr.Value.Any(), want)
 			}
 		}
 	}

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -463,6 +463,9 @@ func LogStages[T any](req Request[T]) (Request[T], error) {
 // purpose of OTEL tracing. An error is returned if the state machine fails, name
 // is empty, the Request Ctx/Next is nil or the Err field is not nil.
 func Run[T any](name string, req Request[T], options ...Option) (Request[T], error) {
+	if req.Ctx == nil {
+		return req, ctxNilErr
+	}
 	req.Ctx = context.AddAttrs(
 		req.Ctx,
 		slog.String("statemachine", name),

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -463,6 +463,12 @@ func LogStages[T any](req Request[T]) (Request[T], error) {
 // purpose of OTEL tracing. An error is returned if the state machine fails, name
 // is empty, the Request Ctx/Next is nil or the Err field is not nil.
 func Run[T any](name string, req Request[T], options ...Option) (Request[T], error) {
+	req.Ctx = context.AddAttrs(
+		req.Ctx,
+		slog.String("statemachine", name),
+		slog.String("reqID", req.reqID),
+	)
+
 	defer func() {
 		if req.seenStages != nil {
 			seenStagesPool.Put(req.Ctx, req.seenStages)
@@ -525,6 +531,7 @@ func Run[T any](name string, req Request[T], options ...Option) (Request[T], err
 
 	for req.Next != nil {
 		stateName := methodName(req.Next)
+		ctx := context.AddAttrs(req.Ctx, slog.String("state", stateName))
 		if req.seenStages != nil {
 			if req.seenStages.seen(stateName) {
 				req.Next = nil
@@ -532,17 +539,17 @@ func Run[T any](name string, req Request[T], options ...Option) (Request[T], err
 			}
 		}
 		if req.logStages {
-			context.Log(req.Ctx).Info(req.Ctx, "statemachine executing state: "+stateName, slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
+			context.Log(ctx).Info(ctx, "statemachine executing state: "+stateName)
 		}
 		req = execState(req, stateName)
 
 		if req.logStages {
-			context.Log(req.Ctx).Info(req.Ctx, "statemachine finished state: "+stateName, slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
+			context.Log(ctx).Info(ctx, "statemachine finished state: "+stateName)
 		}
 		if req.Err != nil {
 			req = execDefer(req)
 			if req.logStages {
-				context.Log(req.Ctx).Info(req.Ctx, fmt.Sprintf("statemachine state(%s) error: %s", stateName, req.Err), slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
+				context.Log(ctx).Info(ctx, fmt.Sprintf("statemachine state(%s) error: %s", stateName, req.Err))
 			}
 			req.span.Status(codes.Error, fmt.Sprintf("error in State(%s): %s", stateName, req.Err.Error()))
 			return req, req.Err

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -532,17 +532,17 @@ func Run[T any](name string, req Request[T], options ...Option) (Request[T], err
 			}
 		}
 		if req.logStages {
-			context.Log(req.Ctx).Info("statemachine executing state: "+stateName, slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
+			context.Log(req.Ctx).Info(req.Ctx, "statemachine executing state: "+stateName, slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
 		}
 		req = execState(req, stateName)
 
 		if req.logStages {
-			context.Log(req.Ctx).Info("statemachine finished state: "+stateName, slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
+			context.Log(req.Ctx).Info(req.Ctx, "statemachine finished state: "+stateName, slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
 		}
 		if req.Err != nil {
 			req = execDefer(req)
 			if req.logStages {
-				context.Log(req.Ctx).Info(fmt.Sprintf("statemachine state(%s) error: %s", stateName, req.Err), slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
+				context.Log(req.Ctx).Info(req.Ctx, fmt.Sprintf("statemachine state(%s) error: %s", stateName, req.Err), slog.String("statemachine", name), slog.String("state", stateName), slog.String("reqID", req.reqID))
 			}
 			req.span.Status(codes.Error, fmt.Sprintf("error in State(%s): %s", stateName, req.Err.Error()))
 			return req, req.Err

--- a/statemachine/statemachine_test.go
+++ b/statemachine/statemachine_test.go
@@ -385,6 +385,9 @@ func TestRun(t *testing.T) {
 			continue
 		}
 		gotReq.Defers = nil // Reset defers to nil after execution to avoid comparison.
+		// Now one cares about context values.
+		test.wantReq.Ctx = context.Background()
+		gotReq.Ctx = context.Background()
 		if diff := pretty.Compare(test.wantReq, gotReq); diff != "" {
 			t.Errorf("TestRun(%s): got diff (-want +got):\n%s", test.name, diff)
 		}

--- a/statemachine/statemachine_test.go
+++ b/statemachine/statemachine_test.go
@@ -385,7 +385,7 @@ func TestRun(t *testing.T) {
 			continue
 		}
 		gotReq.Defers = nil // Reset defers to nil after execution to avoid comparison.
-		// Now one cares about context values.
+		// No one cares about context values.
 		test.wantReq.Ctx = context.Background()
 		gotReq.Ctx = context.Background()
 		if diff := pretty.Compare(test.wantReq, gotReq); diff != "" {


### PR DESCRIPTION
This creates a custom logger when we do context.Log(ctx) which makes a Context mandatory and removes things like DebugContext().

This makes it so we will always honor context log attributes when logging and not accidentally skip them because we went with the none context logging option.  