### PR TITLE
Bug fixes found by an audit

### DIFF
--- a/concurrency/sync/group.go
+++ b/concurrency/sync/group.go
@@ -59,7 +59,9 @@ func (e *Errors) Add(i int, err error) {
 func (e *Errors) Errors() []error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return e.errs
+	cp := make([]error, len(e.errs))
+	copy(cp, e.errs)
+	return cp
 }
 
 // Error returns all the errors joined together with errors.Join()
@@ -198,7 +200,7 @@ func (w *Group) Go(ctx context.Context, f func(ctx context.Context) error, optio
 	// Since this wasn't the initial setup, we need to attach the span to the context.
 	if !didOnce {
 		if span.Get(ctx).IsRecording() {
-			otelTrace.ContextWithSpan(ctx, w.span.Span)
+			ctx = otelTrace.ContextWithSpan(ctx, w.span.Span)
 		}
 	}
 

--- a/concurrency/sync/group.go
+++ b/concurrency/sync/group.go
@@ -59,6 +59,9 @@ func (e *Errors) Add(i int, err error) {
 func (e *Errors) Errors() []error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if len(e.errs) == 0 {
+		return nil
+	}
 	cp := make([]error, len(e.errs))
 	copy(cp, e.errs)
 	return cp

--- a/concurrency/sync/internal/shardmap/map.go
+++ b/concurrency/sync/internal/shardmap/map.go
@@ -127,9 +127,9 @@ func (m *Map[K, V]) Len() int {
 	m.initDo()
 	var len int
 	for i := 0; i < m.shards; i++ {
-		m.mus[i].Lock()
+		m.mus[i].RLock()
 		len += m.maps[i].Len()
-		m.mus[i].Unlock()
+		m.mus[i].RUnlock()
 	}
 	return len
 }

--- a/concurrency/sync/singleflight.go
+++ b/concurrency/sync/singleflight.go
@@ -74,7 +74,7 @@ type Flight[K comparable, V any] struct {
 // FlightResult holds the results of Do, so they can be passed
 // on a channel.
 type FlightResult[V any] struct {
-	Val    any
+	Val    V
 	Err    error
 	Shared bool
 }

--- a/concurrency/sync/singleflight_test.go
+++ b/concurrency/sync/singleflight_test.go
@@ -408,7 +408,7 @@ func ExampleFlight() {
 	fmt.Println("Shared:", res2.Shared)
 	// Only the first function is executed: it is registered and started with "key",
 	// and doesn't complete before the second function is registered with a duplicate key.
-	fmt.Println("Equal results:", res1.Val.(string) == res2.Val.(string))
+	fmt.Println("Equal results:", res1.Val == res2.Val)
 	fmt.Println("Result:", res1.Val)
 
 	// Output:

--- a/concurrency/sync/testing/group_test.go
+++ b/concurrency/sync/testing/group_test.go
@@ -164,3 +164,32 @@ func TestIndexErrors(t *testing.T) {
 		t.Fatalf("TestIndexErrors: want no missing indexes, got %v", expect)
 	}
 }
+
+// TestErrorsReturnsDefensiveCopy verifies that Errors() returns a copy of the
+// internal slice, not a reference to it. Without a copy, a caller can mutate
+// the internal error list by writing to the returned slice.
+func TestErrorsReturnsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	var errs sync.Errors
+
+	// Add enough errors so that append won't reallocate when we add one more
+	// (we want the snapshot and internal slice to share the same backing array).
+	for i := 0; i < 8; i++ {
+		errs.Add(i, fmt.Errorf("err-%d", i))
+	}
+
+	// Take a snapshot.
+	snapshot := errs.Errors()
+
+	// Mutate the snapshot. If Errors() returned the internal slice directly,
+	// this overwrites the internal state.
+	original := snapshot[0].Error()
+	snapshot[0] = errors.New("MUTATED")
+
+	// Read again from the Errors struct.
+	fresh := errs.Errors()
+	if fresh[0].Error() != original {
+		t.Errorf("TestErrorsReturnsDefensiveCopy: mutating returned slice affected internal state: got %q, want %q", fresh[0].Error(), original)
+	}
+}

--- a/concurrency/worker/looper.go
+++ b/concurrency/worker/looper.go
@@ -81,7 +81,7 @@ func Seq[K comparable, V any](ctx context.Context, pool *Pool, seq iter.Seq2[K, 
 // Wait loops over an iter.Seq2 and calls the provided function for each key/value pair. It will automatically
 // wait for all functions to complete before returning. It automatically breaks if the Context is cancelled.
 // It uses the provided Pool to manage concurrency.
-func Wait[K comparable, V any, A any](ctx context.Context, pool *Pool, seq iter.Seq2[K, V], f Func[K, V], options ...LoopOption) error {
+func Wait[K comparable, V any](ctx context.Context, pool *Pool, seq iter.Seq2[K, V], f Func[K, V], options ...LoopOption) error {
 	opts := opts{}
 	for _, o := range options {
 		opts = o(opts)

--- a/concurrency/worker/looper_test.go
+++ b/concurrency/worker/looper_test.go
@@ -259,7 +259,7 @@ func TestWait(t *testing.T) {
 		}
 
 		seq := SliceSeq2(test.slice)
-		err := Wait[int, int, any](ctx, pool, seq, f)
+		err := Wait[int, int](ctx, pool, seq, f)
 
 		switch {
 		case err == nil && test.wantErr:
@@ -300,7 +300,7 @@ func TestWaitWithCancelOnError(t *testing.T) {
 		return nil
 	}
 
-	err = Wait[int, int, any](ctx, pool, seq, f, WithCancelOnError())
+	err = Wait[int, int](ctx, pool, seq, f, WithCancelOnError())
 	if err == nil {
 		t.Errorf("TestWaitWithCancelOnError: got err == nil, want err != nil")
 	}
@@ -403,7 +403,7 @@ func TestWaitWithMap(t *testing.T) {
 		return nil
 	}
 
-	err = Wait[string, int, any](ctx, pool, seq, f)
+	err = Wait[string, int](ctx, pool, seq, f)
 	if err != nil {
 		t.Errorf("TestWaitWithMap: got err == %s, want err == nil", err)
 	}

--- a/concurrency/worker/priority.go
+++ b/concurrency/worker/priority.go
@@ -78,7 +78,6 @@ type Queue struct {
 	done        chan struct{}
 	running     atomic.Int64
 	queueLen    atomic.Int64
-	queueWait   sync.WaitGroup
 	processWait sync.WaitGroup
 	size        chan struct{}
 	mu          sync.Mutex
@@ -131,7 +130,6 @@ func (d *Queue) Wait(ctx context.Context) error {
 	Default().Submit(
 		ctx,
 		func() {
-			d.queueWait.Wait()
 			d.processWait.Wait()
 			close(done)
 		},

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -510,14 +510,6 @@ func (p *Pool) Sub(ctx context.Context, name string) *Pool {
 		pm = newPoolMetrics(meter)
 	}
 
-	// TODO: I'm not sure we need this. This will always be limited by the parent pool.
-	var goRoutines int64
-	if p.opts.size > 0 {
-		goRoutines = int64(p.opts.size)
-	} else {
-		goRoutines = int64(numCPU)
-	}
-
 	pool := &Pool{
 		queue:      p.queue,
 		opts:       p.opts,
@@ -526,7 +518,6 @@ func (p *Pool) Sub(ctx context.Context, name string) *Pool {
 		goRoutines: p.goRoutines,
 		child:      true,
 	}
-	pool.goRoutines.Add(goRoutines)
 
 	return pool
 }
@@ -558,8 +549,8 @@ type runArgs struct {
 func (r runArgs) run() {
 	r.p.running.Add(1)
 	r.f()
-	r.done()
 	r.p.running.Add(-1)
+	r.done()
 }
 
 // done is called when the job is done.
@@ -599,14 +590,14 @@ func (r runner) run() {
 	if r.timeout > 0 {
 		t = time.NewTimer(r.timeout)
 		if r.metrics != nil {
-			r.metrics.StaticExists.Add(context.Background(), 1)
-			defer r.metrics.StaticExists.Add(context.Background(), -1)
-		}
-	} else {
-		if r.metrics != nil {
 			r.metrics.DynamicExists.Add(context.Background(), 1)
 			defer r.metrics.DynamicExists.Add(context.Background(), -1)
 			r.metrics.DynamicTotal.Add(context.Background(), 1)
+		}
+	} else {
+		if r.metrics != nil {
+			r.metrics.StaticExists.Add(context.Background(), 1)
+			defer r.metrics.StaticExists.Add(context.Background(), -1)
 		}
 	}
 	r.goRoutines.Add(1)

--- a/concurrency/worker/worker_test.go
+++ b/concurrency/worker/worker_test.go
@@ -168,6 +168,83 @@ func TestSubPool(t *testing.T) {
 	}
 }
 
+func TestRunningZeroAfterWait(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// The bug: done() calls wg.Done() before running.Add(-1). This means
+	// Wait() (which calls wg.Wait()) can return while Running() is still > 0.
+	// We use runtime.Gosched() in the submitted work to increase the chance
+	// of the scheduler switching between wg.Done() and running.Add(-1).
+	failed := false
+	for iter := 0; iter < 5000; iter++ {
+		p, err := New(ctx, "", WithSize(1))
+		if err != nil {
+			t.Fatalf("TestRunningZeroAfterWait: got err == %s, want err == nil", err)
+		}
+
+		p.Submit(ctx, func() {
+			runtime.Gosched()
+		})
+		p.Wait()
+
+		if got := p.Running(); got != 0 {
+			t.Errorf("TestRunningZeroAfterWait(iter %d): got Running() == %d, want 0 after Wait()", iter, got)
+			failed = true
+			p.Close(ctx)
+			break
+		}
+		p.Close(ctx)
+	}
+	if !failed {
+		t.Log("TestRunningZeroAfterWait: race did not trigger in 5000 iterations (may need fix anyway)")
+	}
+}
+
+func TestSubPoolDoesNotInflateGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	size := 4
+	p, err := New(ctx, "inflateTest", WithSize(size))
+	if err != nil {
+		t.Fatalf("TestSubPoolDoesNotInflateGoRoutines: got err == %s, want err == nil", err)
+	}
+	defer p.Close(ctx)
+
+	// After creation, the pool should have exactly `size` goroutines.
+	// Give runners a moment to start.
+	time.Sleep(100 * time.Millisecond)
+	baseline := p.GoRoutines()
+
+	// Create multiple sub pools. Each Sub() call should NOT inflate the counter.
+	sub1 := p.Sub(ctx, "sub1")
+	sub2 := p.Sub(ctx, "sub2")
+	sub3 := p.Sub(ctx, "sub3")
+
+	afterSubs := p.GoRoutines()
+
+	// The bug: each Sub() adds p.opts.size to the shared goRoutines counter,
+	// so after 3 Sub() calls the counter is inflated by 3 * size.
+	// The correct behavior is that Sub() should not change the counter at all
+	// since no new goroutines are created.
+	if afterSubs != baseline {
+		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: GoRoutines() changed after Sub() calls: baseline %d, after 3 Sub() calls %d (inflated by %d)", baseline, afterSubs, afterSubs-baseline)
+	}
+
+	// Verify the subs share the same counter value.
+	if sub1.GoRoutines() != p.GoRoutines() {
+		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub1 and parent have different GoRoutines()")
+	}
+	if sub2.GoRoutines() != p.GoRoutines() {
+		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub2 and parent have different GoRoutines()")
+	}
+	if sub3.GoRoutines() != p.GoRoutines() {
+		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub3 and parent have different GoRoutines()")
+	}
+}
+
 func TestLimitedPoolWarning(t *testing.T) {
 	// Save and restore original warnTimer
 	originalWarnTimer := warnTimer

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -83,12 +83,12 @@ func TestMetrics(t *testing.T) {
 			want: defaultProvider,
 		},
 		{
-			name: "NoAuditClientAttached",
+			name: "NoMetricsProviderAttached",
 			ctx:  context.Background(),
 			want: defaultProvider,
 		},
 		{
-			name: "InvalidAuditClientType",
+			name: "InvalidMetricsProviderType",
 			ctx: func() context.Context {
 				ctx := context.Background()
 				return context.WithValue(ctx, metricsKey{}, "invalid")
@@ -122,12 +122,12 @@ func TestTasks(t *testing.T) {
 			want: defaultTasks,
 		},
 		{
-			name: "NoAuditClientAttached",
+			name: "NoTasksAttached",
 			ctx:  context.Background(),
 			want: defaultTasks,
 		},
 		{
-			name: "InvalidAuditClientType",
+			name: "InvalidTasksType",
 			ctx: func() context.Context {
 				ctx := context.Background()
 				return context.WithValue(ctx, tasksKey{}, "invalid")

--- a/context/stdlib.go
+++ b/context/stdlib.go
@@ -152,9 +152,8 @@ func TODO() Context {
 // string or any other built-in type to avoid collisions between
 // packages using context. Users of WithValue should define their own
 // types for keys. To avoid allocating when assigning to an
-// interface{}, context keys often have concrete type
-// struct{}. Alternatively, exported context
-func WithValue(parent Context, key, val interface{}) Context {
+// any, context keys often have concrete type struct{}.
+func WithValue(parent Context, key, val any) Context {
 	return context.WithValue(parent, key, val)
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -477,10 +477,10 @@ func (e Error) TraceAttrs(ctx context.Context, prepend string, attrs span.Attrib
 
 	// Unlike logging, we don't add time, as that gets recorded on the span.
 	// No need for TraceID as it's already on the span.
-	if e.Category.Category() != "" {
+	if e.Category != nil && e.Category.Category() != "" {
 		attrs.Add(attribute.String("Category", e.Category.Category()))
 	}
-	if e.Type.Type() != "" {
+	if e.Type != nil && e.Type.Type() != "" {
 		attrs.Add(attribute.String("Type", e.Type.Type()))
 	}
 	attrs.Add(attribute.String("ErrSrc", e.File))
@@ -515,6 +515,7 @@ func slogAttrToOtelAttr(namespace []string, kv slog.Attr) []attribute.KeyValue {
 		if kv.Value.Uint64() < math.MaxInt64 {
 			return []attribute.KeyValue{attribute.Int64(key, int64(kv.Value.Uint64()))}
 		}
+		log.Default().Warn(fmt.Sprintf("slogAttrToOtelAttr: uint64 value %d for key %q exceeds int64 range, attribute dropped", kv.Value.Uint64(), key))
 	case slog.KindFloat64:
 		return []attribute.KeyValue{attribute.Float64(key, kv.Value.Float64())}
 	case slog.KindString:
@@ -544,6 +545,7 @@ func slogAttrToOtelAttr(namespace []string, kv slog.Attr) []attribute.KeyValue {
 	case slog.KindGroup:
 		return slogAttrsToOtelAttrs(namespace, kv.Value.Group())
 	case slog.KindAny, slog.KindLogValuer:
+		log.Default().Warn(fmt.Sprintf("slogAttrToOtelAttr: unsupported slog.Value kind %v for key %q, attribute dropped", kv.Value.Kind(), key))
 		return nil
 	}
 	return nil

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -686,6 +686,17 @@ func TestTraceAttrs(t *testing.T) {
 			},
 		},
 		{
+			name: "Success: Error with nil Category and nil Type does not panic",
+			err: Error{
+				File: "test.go",
+				Line: 7,
+			},
+			want: []attribute.KeyValue{
+				attribute.String("ErrSrc", "test.go"),
+				attribute.Int("ErrLine", 7),
+			},
+		},
+		{
 			name: "Success: attrs.Err() returns early",
 			err: Error{
 				Category: CatReq,
@@ -740,7 +751,7 @@ func TestSlogAttrsToOtelAttrs(t *testing.T) {
 			want:      []attribute.KeyValue{attribute.Int64("ns.count", 100)},
 		},
 		{
-			name:      "Success: Uint64 exceeding int64 range returns nothing",
+			name:      "Success: Uint64 exceeding int64 range is dropped with warning",
 			namespace: []string{"ns"},
 			attrs:     []slog.Attr{slog.Uint64("big", math.MaxUint64)},
 			want:      []attribute.KeyValue{},

--- a/errors/example/errors.go
+++ b/errors/example/errors.go
@@ -70,7 +70,7 @@ var catToProto = map[Category]pb.ErrorCategory{
 }
 
 func init() {
-	if len(catToProto) != len(pb.ErrorType_name) {
+	if len(catToProto) != len(pb.ErrorCategory_name) {
 		panic("catToProto is not complete")
 	}
 }

--- a/genproject/tmpls/context.tmpl
+++ b/genproject/tmpls/context.tmpl
@@ -140,7 +140,7 @@ func SetEOptions(ctx context.Context, options ...errors.EOption) context.Context
 }
 
 // Everything below here is a wrapper around the stdlib context package.
-// We do this to prevent having to import the stdlib ctonext package in every file that needs it.
+// We do this to prevent having to import the stdlib context package in every file that needs it.
 
 var (
 	// Canceled is the error returned by [Context.Err] when the context is canceled.
@@ -289,9 +289,8 @@ func TODO() Context {
 // string or any other built-in type to avoid collisions between
 // packages using context. Users of WithValue should define their own
 // types for keys. To avoid allocating when assigning to an
-// interface{}, context keys often have concrete type
-// struct{}. Alternatively, exported context
-func WithValue(parent Context, key, val interface{}) Context {
+// any, context keys often have concrete type struct{}.
+func WithValue(parent Context, key, val any) Context {
 	return context.WithValue(parent, key, val)
 }
 

--- a/genproject/tmpls/errors.tmpl
+++ b/genproject/tmpls/errors.tmpl
@@ -132,7 +132,7 @@ func Is(err, target error) bool {
 
 // As finds the first error in err's chain that matches target, and if so, sets
 // target to that error value and returns true.
-func As(err error, target interface{}) bool {
+func As(err error, target any) bool {
 	return errors.As(err, target)
 }
 

--- a/init/geninit/gen.go
+++ b/init/geninit/gen.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"unicode"
 
 	_ "embed"
 )
@@ -35,7 +36,7 @@ func main() {
 	if strings.ToLower(*pkgName) != *pkgName {
 		panic("pkg flag must be lowercase")
 	}
-	if strings.Title(*initName) != *initName {
+	if len(*initName) == 0 || !unicode.IsUpper(rune((*initName)[0])) {
 		panic("init flag must be title case")
 	}
 	args := tmplArgs{

--- a/init/geninit/gen_test.go
+++ b/init/geninit/gen_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestInitTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpl, err := template.New("init").Parse(initTmpl)
+	if err != nil {
+		t.Fatalf("TestInitTemplate: failed to parse template: %s", err)
+	}
+
+	args := tmplArgs{
+		PkgName: "myservice",
+		Initer:  "Init",
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, args); err != nil {
+		t.Fatalf("TestInitTemplate: failed to execute template: %s", err)
+	}
+
+	output := buf.String()
+
+	if !strings.HasPrefix(output, "package myservice") {
+		t.Errorf("TestInitTemplate: output does not start with 'package myservice', got prefix: %q", output[:min(50, len(output))])
+	}
+
+	if strings.Contains(output, "gointt") {
+		t.Errorf("TestInitTemplate: output contains typo 'gointt', want 'goinit'")
+	}
+
+	if strings.Contains(output, "return goinit.Service") {
+		t.Errorf("TestInitTemplate: output contains 'return goinit.Service' in void function")
+	}
+
+	if strings.Contains(output, "return goinit.Close") {
+		t.Errorf("TestInitTemplate: output contains 'return goinit.Close' in void function")
+	}
+}

--- a/init/geninit/init.tmpl
+++ b/init/geninit/init.tmpl
@@ -1,9 +1,12 @@
-package {.PkgName}}
+package {{.PkgName}}
 
 import (
-	"context"
+	"log/slog"
 
 	goinit "github.com/gostdlib/base/init"
+	"github.com/gostdlib/base/concurrency/worker"
+	"go.opentelemetry.io/otel/metric"
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 /*
@@ -31,7 +34,7 @@ func WithValue(i InitArgs, key, value any) InitArgs {
 }
 
 // Meta is metadata about the service.
-type Meta = gointt.Meta
+type Meta = goinit.Meta
 
 // InitFunc is a function that is called during {{.Initer}}() in order to setup various needs
 // for the service. These happen in the order they are registered, so if one has a dependency
@@ -133,7 +136,7 @@ func WithPool(p *worker.Pool, noDefault bool) Option {
 // - Integrates various clients and error packages with each other
 // - Run user provided initializers
 func {{.Initer}}(args InitArgs, options ...Option) {
-    return goinit.Service(args, options...)
+    goinit.Service(args, options...)
 }
 
 // Close is used as a defer function in the main function of a service after Init.
@@ -143,5 +146,5 @@ func {{.Initer}}(args InitArgs, options ...Option) {
 // via RegisterClose() will be called in parallel. This will return in 30 seconds no matter
 // if all closers are done or not.
 func Close(args InitArgs) {
-    return goinit.Close(args)
+    goinit.Close(args)
 }

--- a/init/init.go
+++ b/init/init.go
@@ -32,7 +32,7 @@ Example of a basic service setup:
 		Build:   "[your image tag]",
 	}
 
-	var initArgs = int.Args{Meta: serviceMeta}
+	var initArgs = InitArgs{Meta: serviceMeta}
 
 	func main() {
 		init.Service(initArgs)
@@ -68,7 +68,7 @@ Example RegisterInit:
 		var mux *http.ServeMux
 
 		// Extract a mux from the InitArgs. If not provided, return an error.
-		v := i.Opaque("httpMuxer")
+		v := i.Value("httpMuxer")
 		if v == nil {
 			return fmt.Errorf("httpMuxer key not found in InitArgs")
 		}
@@ -101,7 +101,7 @@ Example RegisterClose:
 		// Init is the function that will be called after init.Service() has done all its setups.
 		func Init(init.InitArgs) error {
 			// Extract a mux from the InitArgs. If not provided, return an error.
-			v := i.Opaque("storageDB")
+			v := i.Value("storageDB")
 			if v == nil {
 				return fmt.Errorf("storageDB key not found in InitArgs")
 			}
@@ -118,7 +118,7 @@ Example RegisterClose:
 		}
 
 		func Close(i IntArgs) {
-			v := i.Opaque("storageDB").(*sql.DB)
+			v := i.Value("storageDB").(*sql.DB)
 			if err := db.Close; err != nil {
 				log.Default().Error(fmt.Sprintf("could not close db: %v", err))
 			}
@@ -269,7 +269,8 @@ type initOpts struct {
 	traceProvider  *sdkTrace.TracerProvider
 	sampleRate     float64
 
-	pool *worker.Pool
+	pool      *worker.Pool
+	noDefault bool
 }
 
 // Option is an optional argument to Init.
@@ -281,6 +282,11 @@ func WithExtraFields(fieldPairs []any) Option {
 	return func(opts *initOpts) error {
 		if len(fieldPairs)%2 != 0 {
 			return fmt.Errorf("extra fields must be key-value pairs")
+		}
+		for i := 0; i < len(fieldPairs); i += 2 {
+			if _, ok := fieldPairs[i].(string); !ok {
+				return fmt.Errorf("extra field keys must be strings, got %T at index %d", fieldPairs[i], i)
+			}
 		}
 		opts.extraFields = fieldPairs
 		return nil
@@ -361,6 +367,7 @@ func WithMetricsPort(p uint16) Option {
 func WithPool(p *worker.Pool, noDefault bool) Option {
 	return func(opts *initOpts) error {
 		opts.pool = p
+		opts.noDefault = noDefault
 		return nil
 	}
 }
@@ -536,7 +543,7 @@ func (s setup) loggerSetup() (stateFn, error) {
 // poolInit is responsible for setting up the worker pool. If a pool is provided, it will be set as the default pool.
 // If not provided, it will be set to a pool with runtime.NumCPUs() workers when Default() is called the first time.
 func (s setup) poolInit() (stateFn, error) {
-	if s.opts.pool != nil {
+	if s.opts.pool != nil && !s.opts.noDefault {
 		if p := worker.Default(); p != nil {
 			log.Default().Error("something is setting the default worker pool before init.Service() and also passing WithPool to Service(), shutting down the old pool")
 			p.Close(context.Background())

--- a/init/init_linux.go
+++ b/init/init_linux.go
@@ -64,22 +64,27 @@ func parseByteSize(s string) (int64, error) {
 		return v, nil
 	}
 
-	suffixes := map[string]int64{
-		"B":   1,
-		"KiB": 1024,
-		"MiB": 1024 * 1024,
-		"GiB": 1024 * 1024 * 1024,
-		"TiB": 1024 * 1024 * 1024 * 1024,
+	type suffixEntry struct {
+		suffix string
+		mult   int64
+	}
+	// Ordered longest-suffix-first so "KiB" matches before "B", etc.
+	suffixes := []suffixEntry{
+		{"TiB", 1024 * 1024 * 1024 * 1024},
+		{"GiB", 1024 * 1024 * 1024},
+		{"MiB", 1024 * 1024},
+		{"KiB", 1024},
+		{"B", 1},
 	}
 
-	for suffix, mult := range suffixes {
-		if strings.HasSuffix(s, suffix) {
-			numStr := strings.TrimSpace(strings.TrimSuffix(s, suffix))
+	for _, entry := range suffixes {
+		if strings.HasSuffix(s, entry.suffix) {
+			numStr := strings.TrimSpace(strings.TrimSuffix(s, entry.suffix))
 			v, err := strconv.ParseInt(numStr, 10, 64)
 			if err != nil {
 				return 0, fmt.Errorf("invalid byte size %q: %w", s, err)
 			}
-			return v * mult, nil
+			return v * entry.mult, nil
 		}
 	}
 

--- a/init/init_linux.go
+++ b/init/init_linux.go
@@ -3,6 +3,7 @@
 package init
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -12,15 +13,37 @@ import (
 // it returns -1. If GOMEMLIMIT is set, it returns that value.
 func containerMemory() (int64, error) {
 	if setting, ok := os.LookupEnv("GOMEMLIMIT"); ok {
-		return strconv.ParseInt(setting, 10, 64)
+		return parseByteSize(setting)
 	}
 
-	data, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+	// Try cgroup v1 first.
+	limit, err := readCgroupMemory("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+	if err == nil && limit > 0 {
+		return int64(float64(limit) * .80), nil
+	}
+
+	// Try cgroup v2.
+	limit, err = readCgroupMemory("/sys/fs/cgroup/memory.max")
+	if err == nil && limit > 0 {
+		return int64(float64(limit) * .80), nil
+	}
+
+	return -1, nil
+}
+
+// readCgroupMemory reads a cgroup memory limit file and returns the value in bytes.
+// Returns -1 if the value is "max" (unlimited) or cannot be parsed.
+func readCgroupMemory(path string) (int64, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return -1, nil
+		return -1, err
 	}
 
 	str := strings.TrimSpace(string(data))
+	if str == "max" {
+		return -1, nil
+	}
+
 	limit, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
 		return -1, err
@@ -28,8 +51,37 @@ func containerMemory() (int64, error) {
 	if limit <= 0 {
 		return -1, nil
 	}
-
-	// We want to use 80% of the memory limit.
-	limit = int64(float64(limit) * .80)
 	return limit, nil
+}
+
+// parseByteSize parses a byte size string that may have suffixes like B, KiB, MiB, GiB, TiB.
+// Plain integers are treated as bytes.
+func parseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+
+	// Try plain integer first.
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return v, nil
+	}
+
+	suffixes := map[string]int64{
+		"B":   1,
+		"KiB": 1024,
+		"MiB": 1024 * 1024,
+		"GiB": 1024 * 1024 * 1024,
+		"TiB": 1024 * 1024 * 1024 * 1024,
+	}
+
+	for suffix, mult := range suffixes {
+		if strings.HasSuffix(s, suffix) {
+			numStr := strings.TrimSpace(strings.TrimSuffix(s, suffix))
+			v, err := strconv.ParseInt(numStr, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid byte size %q: %w", s, err)
+			}
+			return v * mult, nil
+		}
+	}
+
+	return 0, fmt.Errorf("invalid byte size %q: unrecognized suffix", s)
 }

--- a/init/parse_test.go
+++ b/init/parse_test.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package init
+
+import (
+	"testing"
+)
+
+func TestParseByteSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:  "Success: plain integer",
+			input: "1073741824",
+			want:  1073741824,
+		},
+		{
+			name:  "Success: bytes suffix",
+			input: "1024B",
+			want:  1024,
+		},
+		{
+			name:  "Success: KiB suffix",
+			input: "100KiB",
+			want:  100 * 1024,
+		},
+		{
+			name:  "Success: MiB suffix",
+			input: "256MiB",
+			want:  256 * 1024 * 1024,
+		},
+		{
+			name:  "Success: GiB suffix",
+			input: "2GiB",
+			want:  2 * 1024 * 1024 * 1024,
+		},
+		{
+			name:  "Success: TiB suffix",
+			input: "1TiB",
+			want:  1024 * 1024 * 1024 * 1024,
+		},
+		{
+			name:  "Success: whitespace trimmed",
+			input: "  512MiB  ",
+			want:  512 * 1024 * 1024,
+		},
+		{
+			name:    "Error: invalid suffix",
+			input:   "100XB",
+			wantErr: true,
+		},
+		{
+			name:    "Error: no number",
+			input:   "MiB",
+			wantErr: true,
+		},
+		{
+			name:    "Error: empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		got, err := parseByteSize(test.input)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestParseByteSize(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("TestParseByteSize(%s): got err == %s, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+		if got != test.want {
+			t.Errorf("TestParseByteSize(%s): got %d, want %d", test.name, got, test.want)
+		}
+	}
+}

--- a/retry/exponential/doc.go
+++ b/retry/exponential/doc.go
@@ -2,7 +2,7 @@
 Package exponential provides an exponential backoff mechanism. Most useful when setting a single policy
 for all retries within a package or set of packages.
 
-THIS IS A TYPE ALIASED VERION OF github.com/Azure/retyr/exponential. IT IS NOT A FORK.
+THIS IS A TYPE ALIASED VERSION OF github.com/Azure/retry/exponential. IT IS NOT A FORK.
 They are type compatible.
 
 This package comes with a default policy, but can be customized for your own needs.
@@ -26,7 +26,7 @@ maximum interval for a policy with the default settings:
 
 	Generating TimeTable for -1 attempts and the following settings:
 	{
-		"InitialInterval":     1000000000, // 100 * time.Millisecond
+		"InitialInterval":     1000000000, // 1 * time.Second
 		"Multiplier":          2,
 		"RandomizationFactor": 0.5,
 		"MaxInterval":         60000000000 // 60 * time.Second,

--- a/rpc/grpc/server/internal/interceptors/stream/stream.go
+++ b/rpc/grpc/server/internal/interceptors/stream/stream.go
@@ -58,7 +58,7 @@ func WithErrConvert(errConvert ErrConvert) Options {
 // New creates a new stream server interceptor that wraps the provided interceptors.
 // Our interceptor is always first in the chain.
 func New(ctx context.Context, errConvert ErrConvert, options ...Options) (*Interceptor, error) {
-	i := &Interceptor{}
+	i := &Interceptor{errConvert: errConvert}
 	for _, o := range options {
 		if err := o(i); err != nil {
 			return nil, err
@@ -83,6 +83,7 @@ func (s *Interceptor) Intercept(srv interface{}, ss grpc.ServerStream, info *grp
 		ctx:          context.Attach(ss.Context()),
 		md:           grpcMeta,
 		intercepts:   s.intercepts,
+		errConvert:   s.errConvert,
 		ServerStream: ss,
 	}
 	// Call the handler with the wrapped stream

--- a/rpc/grpc/server/internal/interceptors/stream/stream_test.go
+++ b/rpc/grpc/server/internal/interceptors/stream/stream_test.go
@@ -9,7 +9,9 @@ import (
 	pb "github.com/gostdlib/base/errors/example/proto"
 
 	"google.golang.org/grpc"
+	codespkg "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 type fakeServerStream struct {
@@ -42,6 +44,25 @@ func (m *testIntercept) Send(ctx context.Context, md grpcContext.Metadata, ss gr
 
 func (m *testIntercept) Recv(ctx context.Context, md grpcContext.Metadata, msg any) error {
 	return m.recvErr
+}
+
+func TestNewAssignsErrConvert(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	convert := func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+		return status.New(codespkg.Internal, e.Error()), nil
+	}
+
+	interceptor, err := New(ctx, convert)
+	if err != nil {
+		t.Fatalf("TestNewAssignsErrConvert: got err == %s, want err == nil", err)
+	}
+
+	if interceptor.errConvert == nil {
+		t.Errorf("TestNewAssignsErrConvert: errConvert is nil, want non-nil (parameter was ignored)")
+	}
 }
 
 func TestStreamInterceptor(t *testing.T) {

--- a/rpc/grpc/server/internal/interceptors/unary/unary.go
+++ b/rpc/grpc/server/internal/interceptors/unary/unary.go
@@ -117,15 +117,15 @@ func (u *Interceptor) errLogAndConvert(ctx context.Context, req any, info *grpc.
 			if cErr != nil {
 				ce := errors.E(ctx, nil, nil, cErr)
 				ce.Log(ctx, md.CallID, md.CustomerID, req)
-				return resp, e
+				return nil, e
 			}
-			return resp, status.Err()
+			return nil, status.Err()
 		}
-		return resp, e
+		return nil, e
 	}
 	e := errors.E(ctx, nil, nil, err)
 	e.Log(ctx, md.CallID, md.CustomerID, req)
-	return resp, e
+	return nil, e
 }
 
 // mustUUID generates a new UUID v7. If it fails, it panics.

--- a/rpc/grpc/server/internal/interceptors/unary/unary_test.go
+++ b/rpc/grpc/server/internal/interceptors/unary/unary_test.go
@@ -169,6 +169,69 @@ func (t *testIntercept) intercept(ctx context.Context, req any, info *grpc.Unary
 	return handler(ctx, req)
 }
 
+func TestErrLogAndConvertReturnsNilResp(t *testing.T) {
+	t.Parallel()
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("customerID", "12345"))
+	info := &grpc.UnaryServerInfo{FullMethod: "/service/method"}
+	req := &pb.HelloReq{Name: "world"}
+
+	tests := []struct {
+		name       string
+		handler    grpc.UnaryHandler
+		errConvert ErrConvert
+	}{
+		{
+			name: "Error: handler returns errors.Error without converter",
+			handler: func(ctx context.Context, req any) (any, error) {
+				return "should-not-be-returned", errors.E(ctx, CatReq, TypeBadRequest, fmt.Errorf("handler error"))
+			},
+			errConvert: nil,
+		},
+		{
+			name: "Error: handler returns errors.Error with converter",
+			handler: func(ctx context.Context, req any) (any, error) {
+				return "should-not-be-returned", errors.E(ctx, CatReq, TypeBadRequest, fmt.Errorf("handler error"))
+			},
+			errConvert: func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+				return status.New(codes.Internal, e.Error()), nil
+			},
+		},
+		{
+			name: "Error: handler returns errors.Error with failing converter",
+			handler: func(ctx context.Context, req any) (any, error) {
+				return "should-not-be-returned", errors.E(ctx, CatReq, TypeBadRequest, fmt.Errorf("handler error"))
+			},
+			errConvert: func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+				return nil, fmt.Errorf("conversion failed")
+			},
+		},
+		{
+			name: "Error: handler returns standard error",
+			handler: func(ctx context.Context, req any) (any, error) {
+				return "should-not-be-returned", fmt.Errorf("standard error")
+			},
+			errConvert: nil,
+		},
+	}
+
+	for _, test := range tests {
+		unary, err := New(ctx, test.errConvert)
+		if err != nil {
+			t.Fatalf("TestErrLogAndConvertReturnsNilResp(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		resp, err := unary.Intercept(ctx, req, info, test.handler)
+		if err == nil {
+			t.Errorf("TestErrLogAndConvertReturnsNilResp(%s): got err == nil, want err != nil", test.name)
+			continue
+		}
+		if resp != nil {
+			t.Errorf("TestErrLogAndConvertReturnsNilResp(%s): got resp == %v, want nil when error is returned", test.name, resp)
+		}
+	}
+}
+
 func TestWithIntercept(t *testing.T) {
 	t.Parallel()
 

--- a/rpc/grpc/server/start.go
+++ b/rpc/grpc/server/start.go
@@ -171,7 +171,9 @@ func (s *starter) setupGW(ctx context.Context) (fn, error) {
 	}
 
 	if len(s.opts.certs) > 0 {
-		tlsconf := &tls.Config{InsecureSkipVerify: true} // We are dialing ourselves, so it should be fine.
+		// InsecureSkipVerify is safe here: the gateway is dialing the gRPC server
+		// on the same process via loopback. No external network is involved.
+		tlsconf := &tls.Config{InsecureSkipVerify: true}
 		creds := credentials.NewTLS(tlsconf)
 		s.opts.gwDial = append(s.opts.gwDial, grpc.WithTransportCredentials(creds))
 	}
@@ -212,13 +214,13 @@ func (s *starter) listenGRPCOnly(ctx context.Context) (fn, error) {
 
 		s.server.mu.Lock()
 		defer s.server.mu.Unlock()
-		s.server = nil
+		s.server.server = nil
 	}()
 	return nil, nil
 }
 
 func (s *starter) listenWithHTTP(ctx context.Context) (fn, error) {
-	s.server.done = make(chan error)
+	s.server.done = make(chan error, 1)
 
 	mux := s.opts.mux
 	if mux == nil {
@@ -250,7 +252,7 @@ func (s *starter) startTLS(ctx context.Context) error {
 
 		s.server.mu.Lock()
 		defer s.server.mu.Unlock()
-		s.server = nil
+		s.server.server = nil
 	}()
 
 	return nil
@@ -266,7 +268,7 @@ func (s *starter) startNonTLS(ctx context.Context) error {
 
 		s.server.mu.Lock()
 		defer s.server.mu.Unlock()
-		s.server = nil
+		s.server.server = nil
 	}()
 
 	return nil
@@ -304,6 +306,7 @@ func (s *starter) router() http.Handler {
 		func(w http.ResponseWriter, r *http.Request) {
 			if len(s.opts.certs) > 0 && r.TLS == nil {
 				http.Error(w, "TLS required", http.StatusUpgradeRequired)
+				return
 			}
 			if r.ProtoMajor == 2 {
 				switch r.Header.Get("Content-Type") {

--- a/rpc/grpc/server/start_test.go
+++ b/rpc/grpc/server/start_test.go
@@ -1,0 +1,80 @@
+package grpc
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+func TestRouterTLSRejectionReturns(t *testing.T) {
+	t.Parallel()
+
+	// Create a starter with TLS certs configured and an httpHandler that would
+	// panic if reached after TLS rejection.
+	s := &starter{
+		server: &Server{},
+		opts: startOptions{
+			certs: []tls.Certificate{{}},
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("TestRouterTLSRejectionReturns: httpHandler was called after TLS rejection, want early return")
+			}),
+		},
+	}
+
+	handler := s.router()
+
+	// Send a non-TLS request (r.TLS == nil) to a server that requires TLS.
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUpgradeRequired {
+		t.Errorf("TestRouterTLSRejectionReturns: got status %d, want %d", rec.Code, http.StatusUpgradeRequired)
+	}
+}
+
+func TestListenGRPCOnlyNilsServerAfterStop(t *testing.T) {
+	t.Parallel()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("TestListenGRPCOnlyNilsServerAfterStop: failed to listen: %s", err)
+	}
+
+	srv := &Server{
+		server: grpc.NewServer(),
+	}
+
+	st := &starter{
+		server: srv,
+		lis:    lis,
+	}
+
+	_, err = st.listenGRPCOnly(t.Context())
+	if err != nil {
+		t.Fatalf("TestListenGRPCOnlyNilsServerAfterStop: got err == %s, want err == nil", err)
+	}
+
+	// Stop the gRPC server so the goroutine completes.
+	srv.server.GracefulStop()
+
+	// Wait for the done channel to close, indicating the goroutine has finished.
+	select {
+	case <-srv.done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("TestListenGRPCOnlyNilsServerAfterStop: timed out waiting for done channel")
+	}
+
+	// After the goroutine completes, server.server should be nil.
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.server != nil {
+		t.Errorf("TestListenGRPCOnlyNilsServerAfterStop: got server.server != nil, want nil after shutdown")
+	}
+}

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -339,6 +339,9 @@ func (r Request[T]) otelStart() Request[T] {
 }
 
 func bytesToStr(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
 	return unsafe.String(&b[0], len(b))
 }
 
@@ -528,12 +531,12 @@ func Run[T any](name string, req Request[T], options ...Option) (Request[T], err
 
 	if req.span.Span != nil && req.span.Span.IsRecording() {
 		req.Ctx, req.span = span.New(req.Ctx, span.WithName(fmt.Sprintf("statemachine(%s)", name)))
-		req.otelStart()
+		req = req.otelStart()
 		defer req.otelEnd()
 	}
 
 	for req.Next != nil {
-		stateName := methodName(req.Next)
+		stateName := MethodName(req.Next)
 		ctx := context.AddAttrs(req.Ctx, slog.String("state", stateName))
 		if req.seenStages != nil {
 			if req.seenStages.seen(stateName) {
@@ -629,20 +632,6 @@ func execState[T any](req Request[T], stateName string) Request[T] {
 		}
 	}
 	return req
-}
-
-// methodName takes a function or a method and returns its name.
-func methodName(method any) string {
-	if method == nil {
-		return "<nil>"
-	}
-	valueOf := reflect.ValueOf(method)
-	switch valueOf.Kind() {
-	case reflect.Func:
-		return strings.TrimSuffix(strings.TrimSuffix(runtime.FuncForPC(valueOf.Pointer()).Name(), "-fm"), "[...]")
-	default:
-		return "<not a function>"
-	}
 }
 
 // MethodName takes a function or a method and returns its name. This is useful in testing

--- a/statemachine/statemachine_test.go
+++ b/statemachine/statemachine_test.go
@@ -535,6 +535,58 @@ func TestExecDefer(t *testing.T) {
 	}
 }
 
+func TestBytesToStr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		b    []byte
+		want string
+	}{
+		{
+			name: "Success: nil byte slice returns empty string",
+			b:    nil,
+			want: "",
+		},
+		{
+			name: "Success: empty byte slice returns empty string",
+			b:    []byte{},
+			want: "",
+		},
+		{
+			name: "Success: non-empty byte slice returns string",
+			b:    []byte("hello"),
+			want: "hello",
+		},
+	}
+
+	for _, test := range tests {
+		got := bytesToStr(test.b)
+		if got != test.want {
+			t.Errorf("TestBytesToStr(%s): got %q, want %q", test.name, got, test.want)
+		}
+	}
+}
+
+func TestOtelStartSetsStartTime(t *testing.T) {
+	t.Parallel()
+
+	req := Request[data]{
+		Ctx:  context.Background(),
+		Data: data{Num: 1},
+	}
+
+	result := req.otelStart()
+
+	// Without OTEL span, otelStart returns early, but startTime should still
+	// be zero since span is not recording. The important thing is that the
+	// return value is a different object than the input when span IS recording.
+	// Here we verify the function returns without panic and returns a valid Request.
+	if result.Ctx == nil {
+		t.Errorf("TestOtelStartSetsStartTime: returned Request has nil Ctx")
+	}
+}
+
 func functionA() {
 	fmt.Println("Function A")
 }
@@ -561,7 +613,7 @@ func TestMethodName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := methodName(test.fn)
+		got := MethodName(test.fn)
 		if got != test.want {
 			t.Errorf("TestMethodName(%s): got %q, want %q", test.name, got, test.want)
 		}

--- a/telemetry/log/log.go
+++ b/telemetry/log/log.go
@@ -101,7 +101,7 @@ func Panicf(format string, v ...any) {
 // Panicln is equivalent to [Println] followed by a call to panic().
 func Panicln(v ...any) {
 	if detect.Env().Prod() {
-		defaultLog.Load().Debug(fmt.Sprint(v...))
+		panic(fmt.Sprint(v...) + "\n")
 	}
 	log.Panicln(v...)
 }
@@ -115,6 +115,7 @@ func Prefix() string {
 func Print(v ...any) {
 	if detect.Env().Prod() {
 		defaultLog.Load().Debug(fmt.Sprint(v...))
+		return
 	}
 	log.Print(v...)
 }
@@ -123,6 +124,7 @@ func Print(v ...any) {
 func Printf(format string, v ...any) {
 	if detect.Env().Prod() {
 		defaultLog.Load().Debug(fmt.Sprintf(format, v...))
+		return
 	}
 	log.Printf(format, v...)
 }
@@ -131,6 +133,7 @@ func Printf(format string, v ...any) {
 func Println(v ...any) {
 	if detect.Env().Prod() {
 		defaultLog.Load().Debug(fmt.Sprintf("%v\n", v...))
+		return
 	}
 	log.Println(v...)
 }

--- a/telemetry/otel/trace/trace.go
+++ b/telemetry/otel/trace/trace.go
@@ -64,6 +64,7 @@ var TracerNameKey = tracerKeyType(1)
 
 var defaultTP *sdkTrace.TracerProvider
 var once sync.Once
+var connTimeout = 5 * time.Second
 
 // Default returns the default trace provider. Normally not required by an end user.
 // TraceProviders are not normally used, instead spans are done via the .../otel/trace/span package
@@ -189,7 +190,7 @@ func prodProvider(ctx context.Context, endpoint string, sampleRate float64) (*sd
 		return nil, fmt.Errorf("failed to create opentelemetry resource: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, connTimeout)
 	defer cancel()
 	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {

--- a/telemetry/otel/trace/trace.go
+++ b/telemetry/otel/trace/trace.go
@@ -175,8 +175,6 @@ func (i *initer) Init() error {
 	return nil
 }
 
-var connTimeout = 5 * time.Second
-
 // If the OpenTelemetry Collector is running on a kubernetes cluster (AKS, GKE, EKS, etc.),
 // it should be accessible through "opentelemetry-collector.<namespace>.svc.cluster.local:<port>".
 func prodProvider(ctx context.Context, endpoint string, sampleRate float64) (*sdkTrace.TracerProvider, error) {
@@ -198,13 +196,15 @@ func prodProvider(ctx context.Context, endpoint string, sampleRate float64) (*sd
 		return nil, fmt.Errorf("failed to create gRPC connection to OTEL collector: %w", err)
 	}
 
-	// grpc's new API sucks. This is the only way to check if the connection is ready that isn't deprecated.
-	// Because, hey, maybe I want to do something else if the endpoint isn't there.
-	// Now, this simply checks that grpc answers, but not that it is the otel collector.
+	// Wait for the connection to be ready. WaitForStateChange blocks until
+	// the state changes from the given state or the context (with 5s timeout) is cancelled.
 	conn.Connect()
-	start := time.Now()
-	for conn.GetState() != connectivity.Ready {
-		if time.Since(start) > connTimeout {
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			break
+		}
+		if !conn.WaitForStateChange(ctx, state) {
 			break
 		}
 	}

--- a/values/generics/promises/promise.go
+++ b/values/generics/promises/promise.go
@@ -135,9 +135,7 @@ func (m *Maker[I, O]) New(ctx context.Context, in I, options ...Option) Promise[
 // New creates a new Promise.
 func New[I, O any](ctx context.Context, in I, options ...Option) Promise[I, O] {
 	resp := make(chan Response[O], 1)
-
-	promise := Promise[I, O]{In: in, v: resp}
-	return promise
+	return newPromise[I, O](in, resp, options...)
 }
 
 func newPromise[I, O any](in I, resp chan Response[O], options ...Option) Promise[I, O] {
@@ -169,8 +167,8 @@ func (p *Promise[I, O]) Get(ctx context.Context) (Response[O], error) {
 }
 
 // Set sets the value of the promise. If the promise has already had Set() called and the value is not read,
-// this will return an error. However, you should never call Set() more than once on a promise.
-func (p *Promise[I, O]) Set(ctx context.Context, v O, err error) error {
+// this will panic. You should never call Set() more than once on a promise.
+func (p *Promise[I, O]) Set(ctx context.Context, v O, err error) {
 	if p.v == nil {
 		panic("promise was not created with New() or Maker{}.New()")
 	}
@@ -179,5 +177,4 @@ func (p *Promise[I, O]) Set(ctx context.Context, v O, err error) error {
 	default:
 		panic("bug in your program: promise was already resolved with a call to Set()")
 	}
-	return nil
 }

--- a/values/isset/bool.go
+++ b/values/isset/bool.go
@@ -40,13 +40,16 @@ func (i Bool) Unset() Bool {
 // MarshalJSON implements the json.Marshaler interface.
 func (i Bool) MarshalJSON() ([]byte, error) {
 	if !i.isSet {
-		return []byte{}, nil
+		return []byte("null"), nil
 	}
 	return json.Marshal(i.v)
 }
 
 // MarshalJSONV2 implements the json.MarshalerV2 interface.
 func (i Bool) MarshalJSONV2(enc *jsontext.Encoder, opts json.Options) error {
+	if !i.isSet {
+		return enc.WriteToken(jsontext.Null)
+	}
 	return enc.WriteToken(jsontext.Bool(bool(i.v)))
 }
 
@@ -84,5 +87,5 @@ func (v *Bool) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Options) error {
 		v.v = t.Bool()
 		return nil
 	}
-	return fmt.Errorf("expected a JSON bool, got %T", t.Kind())
+	return fmt.Errorf("expected a JSON bool, got %v", t.Kind())
 }

--- a/values/isset/bool_test.go
+++ b/values/isset/bool_test.go
@@ -91,7 +91,7 @@ func TestBoolMarshalling(t *testing.T) {
 			jsonInput:  "",
 			wantBool:   false,
 			wantIsSet:  false,
-			wantOutput: "",
+			wantOutput: "null",
 		},
 		{
 			name:       "Unmarshal set Bool",

--- a/values/isset/float.go
+++ b/values/isset/float.go
@@ -46,13 +46,16 @@ func (i floatType[T]) Unset() floatType[T] {
 // MarshalJSON implements the json.Marshaler interface.
 func (i floatType[T]) MarshalJSON() ([]byte, error) {
 	if !i.isSet {
-		return []byte{}, nil
+		return []byte("null"), nil
 	}
 	return json.Marshal(i.v)
 }
 
 // MarshalJSONV2 implements the json.MarshalerV2 interface.
 func (i floatType[T]) MarshalJSONV2(enc *jsontext.Encoder, opts json.Options) error {
+	if !i.isSet {
+		return enc.WriteToken(jsontext.Null)
+	}
 	return enc.WriteToken(jsontext.Float(float64(i.v)))
 }
 
@@ -91,5 +94,5 @@ func (v *floatType[T]) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Options)
 		v.v = T(t.Float())
 		return nil
 	}
-	return fmt.Errorf("expected a JSON number, got %T", t.Kind())
+	return fmt.Errorf("expected a JSON number, got %v", t.Kind())
 }

--- a/values/isset/float_test.go
+++ b/values/isset/float_test.go
@@ -91,7 +91,7 @@ func TestFloat64Marshalling(t *testing.T) {
 			jsonInput:   "",
 			wantFloat64: 0,
 			wantIsSet:   false,
-			wantOutput:  "",
+			wantOutput:  "null",
 		},
 		{
 			name:        "Unmarshal set Float64",

--- a/values/isset/int.go
+++ b/values/isset/int.go
@@ -55,13 +55,16 @@ func (i intType[T]) Unset() intType[T] {
 // MarshalJSON implements the json.Marshaler interface.
 func (i intType[T]) MarshalJSON() ([]byte, error) {
 	if !i.isSet {
-		return []byte{}, nil
+		return []byte("null"), nil
 	}
 	return json.Marshal(i.v)
 }
 
 // MarshalJSONV2 implements the json.MarshalerV2 interface.
 func (i intType[T]) MarshalJSONV2(enc *jsontext.Encoder, opts json.Options) error {
+	if !i.isSet {
+		return enc.WriteToken(jsontext.Null)
+	}
 	return enc.WriteToken(jsontext.Int(int64(i.v)))
 }
 
@@ -100,5 +103,5 @@ func (v *intType[T]) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Options) e
 		v.v = T(t.Int())
 		return nil
 	}
-	return fmt.Errorf("expected a JSON number, got %T", t.Kind())
+	return fmt.Errorf("expected a JSON number, got %v", t.Kind())
 }

--- a/values/isset/int_test.go
+++ b/values/isset/int_test.go
@@ -91,7 +91,7 @@ func TestIntMarshalling(t *testing.T) {
 			jsonInput:  "",
 			wantInt:    0,
 			wantIsSet:  false,
-			wantOutput: "",
+			wantOutput: "null",
 		},
 		{
 			name:       "Unmarshal set Int",

--- a/values/isset/string.go
+++ b/values/isset/string.go
@@ -40,13 +40,16 @@ func (i String) Unset() String {
 // MarshalJSON implements the json.Marshaler interface.
 func (i String) MarshalJSON() ([]byte, error) {
 	if !i.isSet {
-		return []byte{}, nil
+		return []byte("null"), nil
 	}
 	return json.Marshal(i.v)
 }
 
 // MarshalJSONV2 implements the json.MarshalerV2 interface.
 func (i String) MarshalJSONV2(enc *jsontext.Encoder, opts json.Options) error {
+	if !i.isSet {
+		return enc.WriteToken(jsontext.Null)
+	}
 	return enc.WriteToken(jsontext.String(string(i.v)))
 }
 
@@ -84,5 +87,5 @@ func (v *String) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Options) error
 		v.v = string(t.String())
 		return nil
 	}
-	return fmt.Errorf("expected a JSON string, got %string", t.Kind())
+	return fmt.Errorf("expected a JSON string, got %v", t.Kind())
 }

--- a/values/isset/string_test.go
+++ b/values/isset/string_test.go
@@ -96,7 +96,7 @@ func TestStringMarshalling(t *testing.T) {
 			jsonInput:  "",
 			wantStr:    "",
 			wantIsSet:  false,
-			wantOutput: "",
+			wantOutput: "null",
 		},
 		{
 			name:       "Unmarshal set String",

--- a/values/isset/uint.go
+++ b/values/isset/uint.go
@@ -55,13 +55,16 @@ func (i uintType[T]) Unset() uintType[T] {
 // MarshalJSON implements the json.Marshaler interface.
 func (i uintType[T]) MarshalJSON() ([]byte, error) {
 	if !i.isSet {
-		return []byte{}, nil
+		return []byte("null"), nil
 	}
 	return json.Marshal(i.v)
 }
 
 // MarshalJSONV2 implements the json.MarshalerV2 interface.
 func (i uintType[T]) MarshalJSONV2(enc *jsontext.Encoder, opts json.Options) error {
+	if !i.isSet {
+		return enc.WriteToken(jsontext.Null)
+	}
 	return enc.WriteToken(jsontext.Uint(uint64(i.v)))
 }
 
@@ -100,5 +103,5 @@ func (v *uintType[T]) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Options) 
 		v.v = T(t.Uint())
 		return nil
 	}
-	return fmt.Errorf("expected a JSON number, got %T", t.Kind())
+	return fmt.Errorf("expected a JSON number, got %v", t.Kind())
 }

--- a/values/isset/uint_test.go
+++ b/values/isset/uint_test.go
@@ -91,7 +91,7 @@ func TestUintMarshalling(t *testing.T) {
 			jsonInput:  "",
 			wantUint:   0,
 			wantIsSet:  false,
-			wantOutput: "",
+			wantOutput: "null",
 		},
 		{
 			name:       "Unmarshal set Uint",


### PR DESCRIPTION
**Concurrency and Worker Pool Fixes:**
- Fixed a race condition in `Pool` where `Wait()` could return before all goroutines finished, ensuring `Running()` is zero after `Wait()`. Added a test to verify this behavior. (F6ebdea3L549, [concurrency/worker/worker_test.goR171-R247](diffhunk://#diff-57ac946b33a009d03cd80b1b8ccdb92ebb2f25a07ac885cfd683fd620b980bc9R171-R247))
- Prevented `Sub()` from incorrectly inflating the goroutine counter in worker pools. Added a test to ensure sub-pools do not increase the goroutine count. [[1]](diffhunk://#diff-b6211ea8e1dd2b56c676cc6dcfb763d4219bacc682d7c6b16214e48addc476adL513-L520) F6ebdea3L518R518, [[2]](diffhunk://#diff-57ac946b33a009d03cd80b1b8ccdb92ebb2f25a07ac885cfd683fd620b980bc9R171-R247)
- Changed `Map.Len()` to use a read lock (`RLock`) instead of a write lock for better concurrency.
- Removed an unused wait group (`queueWait`) from `Queue` and its usage in `Wait()`, simplifying the priority queue implementation. ([concurrency/worker/priority.goL81](diffhunk://#diff-61597c9097cc1893f17cc4639831c94b2a2cf44ace0c10946c553cd971c03ac6L81), F783bc52L130R131)

**Error Handling and Defensive Programming:**
- Made `Errors.Errors()` return a defensive copy of the internal slice to prevent external mutation, and added a test to verify this behavior. [[1]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L62-R64) [[2]](diffhunk://#diff-781c71d35091683ca604a088f4ed5e2cab3bb94b09bcb83215659b99219266afR167-R195)
- Improved error attribute handling to avoid panics when `Category` or `Type` is nil, and added a test for this scenario. [[1]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13L480-R483) [[2]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8R688-R698)
- Added warnings when unsupported or out-of-range attributes are dropped during error-to-otel attribute conversion. ([errors/errors.goR518](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13R518), F90bc018L545R544, F7df83c4L751R740)

**API and Type Improvements:**
- Updated function signatures and type usage to use `any` instead of `interface{}` for better Go 1.18+ idiomatic code, including `WithValue` and `As` functions. [[1]](diffhunk://#diff-e20d729bc7c0db18c1f950f890389e65ec6ff23bc28afdbad00e685ca40664acL155-R156) [[2]](diffhunk://#diff-4bf4bf0f2424c8dbdf658d975c87e3da82708ef95d9c1bf2bd88eb9faa291a58L292-R293) [[3]](diffhunk://#diff-f999890729103891d7c88f6e642b0232a65931275c20942109e403ed6c38803cL135-R135)
- Fixed the type of `FlightResult.Val` to use the generic type parameter instead of `any`, improving type safety.
- Updated `Wait` function and its tests to remove an unused type parameter. [[1]](diffhunk://#diff-06e60720c642dc72ad179724106885f8abd4bfdb60b9b83b965e62e3cc9581ccL84-R84) [[2]](diffhunk://#diff-3d4b9c71a955d34a4e78ca411f4bc7b50396cdcfe4aab708e519cece3bfc3c2dL262-R262) [[3]](diffhunk://#diff-3d4b9c71a955d34a4e78ca411f4bc7b50396cdcfe4aab708e519cece3bfc3c2dL303-R303) [[4]](diffhunk://#diff-3d4b9c71a955d34a4e78ca411f4bc7b50396cdcfe4aab708e519cece3bfc3c2dL406-R406)

**Context and Test Naming Consistency:**
- Improved test case naming for metrics and tasks context tests for clarity and accuracy. [[1]](diffhunk://#diff-f3c274442d3d0c085ca04f8d63d7fb3a26dd41b53bf3fb0000d54cc4cffe84f8L86-R91) [[2]](diffhunk://#diff-f3c274442d3d0c085ca04f8d63d7fb3a26dd41b53bf3fb0000d54cc4cffe84f8L125-R130)
- Fixed a typo in a comment regarding the import of the standard library context package.

**Other Improvements:**
- Improved validation for the `init` flag in `geninit` to check for proper title casing using `unicode.IsUpper`. ([init/geninit/gen.goR8](diffhunk://#diff-a3482d660a2e9cc817d4f164b7ba7305318f56c14a83d6ac18b105550105d916R8), F7f2133eL36R35)
- Fixed a panic condition in `catToProto` initialization by using the correct proto map for error categories.
- Ensured context is updated when attaching a span in `Group.Go`. (F4a73855L200R198)
- Changed the order of operations in `runArgs.run()` to ensure proper decrementing of running goroutine count before signaling completion. (F6ebdea3L549R558)
- Refactored metrics increment/decrement logic in the worker runner for clarity and correctness. (F6ebdea3L589R598)