### PR TITLE
Errors cleanup [breaking]

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -173,14 +173,11 @@ base for your package.
 package errors
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
-	"net/http"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -195,11 +192,8 @@ import (
 	"github.com/gostdlib/base/telemetry/otel/metrics"
 	"github.com/gostdlib/base/telemetry/otel/trace/span"
 
-	"github.com/go-json-experiment/json"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 
 	otelTrace "go.opentelemetry.io/otel/trace"
 )
@@ -243,7 +237,7 @@ var _ errImplements = Error{}
 // "errors" package for their service with an E() method that creates a type that returns Error
 // with their information. Any type that implements Error should also
 // be JSON serializable for logging output.
-// Error represents an error that has a category and a type. Created with E().
+// Error represents an error that has a category and a type. Created with E(), should not be hand created.
 type Error struct {
 	// Category is the category of the error. Should always be provided.
 	Category Category
@@ -268,6 +262,14 @@ type Error struct {
 	// StackTrace is the stack trace of the error. This is automatically filled
 	// in by E() if WithStackTrace() is used.
 	StackTrace string
+	// LogLevel is the log level that should be used when logging this error. By default this is
+	// slog.LevelError, but in some cases you may want to log at a different level, such as slog.LevelWarn for a retryable error.
+	LogLevel slog.Level
+	// IsFunc is a function that can be used to override the Is() method. This is useful for
+	// cases where you want to consider two errors the same even if they have different categories or types,
+	// such as in the case of a SQLQueryErr where you want to consider all SQLQueryErrs the same regardless of the
+	// query or error message.
+	IsFunc func(target error) bool
 
 	attrs []slog.Attr
 }
@@ -314,6 +316,16 @@ func WithAttrs(attrs ...slog.Attr) EOption {
 	}
 }
 
+// WithLogLevel sets the log level that should be used when logging this error. By default this is
+// slog.LevelError, but in some cases you may want to log at a different level, such as slog.LevelWarn for a retryable error.
+// Note that this does not affect the trace status, which will still be recorded as an error unless WithSuppressTraceErr() is used.
+func WithLogLevel(level slog.Level) EOption {
+	return func(e ierr.EOpts) ierr.EOpts {
+		e.LogLevel = level
+		return e
+	}
+}
+
 var now = time.Now
 
 // E creates a new Error with the given parameters. If the message is already an Error, it will be returned instead.
@@ -322,7 +334,7 @@ func E(ctx context.Context, c Category, t Type, msg error, options ...EOption) E
 		return e
 	}
 
-	opts := ierr.EOpts{CallNum: 1}
+	opts := ierr.EOpts{CallNum: 1, LogLevel: slog.LevelError}
 
 	// Apply local options.
 	for _, o := range options {
@@ -360,8 +372,8 @@ func E(ctx context.Context, c Category, t Type, msg error, options ...EOption) E
 		Msg:        msg,
 		ErrTime:    now().UTC(),
 		StackTrace: st,
-
-		attrs: attrs,
+		LogLevel:   opts.LogLevel,
+		attrs:      attrs,
 	}
 
 	e.trace(ctx, opts.SuppressTraceErr)
@@ -378,14 +390,22 @@ func (e Error) Error() string {
 }
 
 // Is implements the errors.Is() interface. An Error is equal to another Error if the category and type are the same.
-// If the target error has a nil category and type, it is considered equal to any Error.
+// If the target error has a nil category and type, then it will not be considered equal to any Error.
+// This is to prevent accidentally considering an error with a nil category and type as equal to all errors.
+// If IsFunc is provided, it will be used instead of the default behavior.
 func (e Error) Is(target error) bool {
 	if target == nil {
 		return false
 	}
+	if e.IsFunc != nil {
+		return e.IsFunc(target)
+	}
 	if targetE, ok := target.(Error); ok {
-		if targetE.Category == nil && targetE.Type == nil {
+		if e.IsZero() && targetE.IsZero() {
 			return true
+		}
+		if targetE.Category == nil && targetE.Type == nil {
+			return false
 		}
 		return e.Category == targetE.Category && e.Type == targetE.Type
 	}
@@ -490,6 +510,11 @@ func (e Error) TraceAttrs(ctx context.Context, prepend string, attrs span.Attrib
 	}
 
 	return attrs
+}
+
+// IsZero returns true if the error is a zero value. This can be used to check if an error has been set or not.
+func (e Error) IsZero() bool {
+	return e.Category == nil && e.Type == nil && e.Msg == nil && e.File == "" && e.Line == 0 && e.ErrTime.IsZero() && e.StackTrace == "" && len(e.attrs) == 0 && e.LogLevel == slog.Level(0) && e.IsFunc == nil
 }
 
 // slogAttrsToOtelAttrs converts a list of slog.Attr to a list of OpenTelemetry attribute.KeyValue.
@@ -619,103 +644,28 @@ func (e Error) metrics() {
 // Log logs the error with the given callID and customerID for easy lookup. Also
 // logs the request that caused the error. The request is expected to be JSON serializable.
 // If the req is a proto, this will used protojson to marshal it.
-func (e Error) Log(ctx context.Context, callID, customerID string, req any) {
-	var reqBytes []byte
-
-	// Ignore serialization errors, it just means we log less information.
-	switch v := req.(type) {
-	case nil:
-	case proto.Message:
-		var err error
-		reqBytes, err = protojson.Marshal(v)
-		if err != nil {
-			reqBytes = fmt.Appendf(reqBytes, "unable to marshal proto.Message due to error: %s", err)
-		}
-	case *http.Request:
-		var err error
-		reqBytes, err = requestToJSON(v)
-		if err != nil {
-			reqBytes = fmt.Appendf(reqBytes, "unable to marshal *http.Request due to error: %s", err)
-		}
-	default:
-		var err error
-		reqBytes, err = json.Marshal(req)
-		if err != nil {
-			reqBytes = fmt.Appendf(reqBytes, "unable to marshal request %T object due to error: %s", req, err.Error())
-		}
+func (e Error) Log(ctx context.Context) {
+	if e.Msg == nil {
+		return
 	}
 
+	ctxAttrs := goctx.Attrs(ctx)
 	logAttrs := e.LogAttrs(ctx)
-	var attrs = make([]slog.Attr, 0, 3+len(logAttrs))
-	if customerID != "" {
-		attrs = append(attrs, slog.Any("CustomerID", customerID))
-	}
-	if callID != "" {
-		attrs = append(attrs, slog.Any("CallID", callID))
-	}
-	if len(reqBytes) > 0 {
-		attrs = append(attrs, slog.Any("Request", bytesToStr(reqBytes)))
-	}
+	var attrs = make([]slog.Attr, 0, 3+len(logAttrs)+len(ctxAttrs))
 	attrs = append(attrs, logAttrs...)
+	attrs = append(attrs, ctxAttrs...)
 
-	// Attach any attributes from the error message.
 	if f, ok := e.Msg.(LogAttrer); ok {
 		attrs = append(attrs, f.LogAttrs(ctx)...)
 	}
 
-	// Look at any wrapped errors and see if they implement Attrer.
 	for err := errors.Unwrap(e.Msg); err != nil; err = errors.Unwrap(err) {
 		if f, ok := err.(LogAttrer); ok {
 			attrs = append(attrs, f.LogAttrs(ctx)...)
 		}
 	}
 
-	errMsg := "error message not provided"
-	if e.Msg != nil {
-		errMsg = e.Msg.Error()
-	}
-
-	log.Default().LogAttrs(ctx, slog.LevelError, errMsg, attrs...)
-}
-
-// JSONRequest is a simplified version of http.Request for JSON serialization
-type JSONRequest struct {
-	Method        string              `json:"method"`
-	URL           string              `json:"url"`
-	Header        map[string][]string `json:"header"`
-	ContentLength int64               `json:"content_length"`
-	Host          string              `json:"host"`
-	RemoteAddr    string              `json:"remote_addr"`
-	RequestURI    string              `json:"request_uri"`
-	Body          string              `json:"body"`
-}
-
-func requestToJSON(r *http.Request) ([]byte, error) {
-	var bodyBytes []byte
-	// Read the original body
-	if r.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(r.Body)
-		if err != nil {
-			return nil, err
-		}
-		r.Body.Close()
-	}
-
-	// Reset the request body so it can be read again
-	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-
-	jr := JSONRequest{
-		Method:        r.Method,
-		URL:           r.URL.String(),
-		Header:        r.Header,
-		ContentLength: r.ContentLength,
-		Host:          r.Host,
-		RemoteAddr:    r.RemoteAddr,
-		RequestURI:    r.RequestURI,
-		Body:          bytesToStr(bodyBytes),
-	}
-	return json.Marshal(jr)
+	log.Default().LogAttrs(ctx, e.LogLevel, e.Msg.Error(), attrs...)
 }
 
 // bytesToStr converts a byte slice to a string without copying the data.

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"net/http"
 	"net/url"
 	"path"
 	"runtime"
@@ -23,8 +22,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	otelTrace "go.opentelemetry.io/otel/trace"
-
-	pb "github.com/gostdlib/base/errors/example/proto"
 )
 
 type TestCat uint8
@@ -129,6 +126,7 @@ func TestE(t *testing.T) {
 				Type:     TypeBadRequest,
 				ErrTime:  ti.UTC(),
 				Msg:      errors.New("bug: nil error"),
+				LogLevel: slog.LevelError,
 			},
 		},
 		{
@@ -148,6 +146,7 @@ func TestE(t *testing.T) {
 				Type:     TypeBadRequest,
 				ErrTime:  ti.UTC(),
 				Msg:      errors.New("error"),
+				LogLevel: slog.LevelError,
 			},
 		},
 	}
@@ -231,12 +230,6 @@ func TestIs(t *testing.T) {
 			name:   "Errors cat and type match",
 			err:    Error{Category: CatReq, Type: TypeBadRequest},
 			target: Error{Category: CatReq, Type: TypeBadRequest},
-			want:   true,
-		},
-		{
-			name:   "Empty Error target matches any Error",
-			err:    Error{Category: CatReq, Type: TypeBadRequest},
-			target: Error{},
 			want:   true,
 		},
 		{
@@ -337,81 +330,38 @@ func TestLog(t *testing.T) {
 	ctxWithSpan := otelTrace.ContextWithSpan(context.Background(), span)
 
 	tests := []struct {
-		name       string
-		e          Error
-		callID     string
-		customerID string
-		req        any
-		ctx        context.Context
-		want       map[string]any
+		name string
+		e    Error
+		ctx  context.Context
+		want map[string]any
 	}{
 		{
-			name: "Empty error with no req",
-			want: map[string]any{
-				"Category":   "Unknown",
-				"CustomerID": "customerID",
-				"ErrSrc":     "",
-				"ErrLine":    0,
-				"CallID":     "callID",
-				"Type":       "Unknown",
-				"ErrTime":    time.Time{}.UTC(),
-				"level":      "ERROR",
-				"msg":        "error message not provided",
-			},
+			name: "Empty error",
+			want: nil,
 		},
 		{
-			name: "Error with everything and a proto req",
+			name: "Error with everything",
 			e: Error{
 				Category: CatReq,
 				File:     "f  ilename",
 				Line:     123,
 				Type:     TypeBadRequest,
 				ErrTime:  ti,
+				LogLevel: slog.LevelError,
 				Msg:      fmt.Errorf("something went wrong"),
 			},
-			req: &pb.Error{Id: "2"},
 			want: map[string]any{
-				"Category":   "Request",
-				"CustomerID": "customerID",
-				"ErrSrc":     "f  ilename",
-				"ErrLine":    123,
-				"Request":    "{\"Id\":\"2\"}",
-				"CallID":     "callID",
-				"ErrTime":    ti.UTC(),
-				"Type":       "BadRequest",
-				"level":      "ERROR",
-				"msg":        "something went wrong",
+				"Category": "Request",
+				"ErrSrc":   "f  ilename",
+				"ErrLine":  123,
+				"ErrTime":  ti.UTC(),
+				"Type":     "BadRequest",
+				"level":    "ERROR",
+				"msg":      "something went wrong",
 			},
 		},
 		{
-			name: "Error with everything and a http.Request",
-			e: Error{
-				Category: CatReq,
-				File:     "f  ilename",
-				Line:     123,
-				Type:     TypeBadRequest,
-				ErrTime:  ti,
-				Msg:      fmt.Errorf("something went wrong"),
-			},
-			req: &http.Request{
-				Method: "GET",
-				URL:    urlMustParse("https://www.microsoft.com"),
-			},
-			want: map[string]any{
-				"Category":   "Request",
-				"CustomerID": "customerID",
-				"ErrSrc":     "f  ilename",
-				"ErrLine":    123,
-				"Request":    "{\"method\":\"GET\",\"url\":\"https://www.microsoft.com\",\"header\":{},\"content_length\":0,\"host\":\"\",\"remote_addr\":\"\",\"request_uri\":\"\",\"body\":\"\"}",
-				"CallID":     "callID",
-				"ErrTime":    ti.UTC(),
-				"Type":       "BadRequest",
-				"level":      "ERROR",
-				"msg":        "something went wrong",
-			},
-		},
-		{
-			name: "Error with everything but a request and a stack trace",
+			name: "Error with a stack trace",
 			e: Error{
 				Category:   CatReq,
 				File:       "filename",
@@ -423,14 +373,12 @@ func TestLog(t *testing.T) {
 			},
 			want: map[string]any{
 				"Category":   "Request",
-				"CustomerID": "customerID",
 				"ErrSrc":     "filename",
 				"ErrLine":    123,
-				"CallID":     "callID",
 				"ErrTime":    ti.UTC(),
 				"Type":       "BadRequest",
 				"StackTrace": "stack trace",
-				"level":      "ERROR",
+				"level":      "INFO",
 				"msg":        "something went wrong",
 			},
 		},
@@ -446,16 +394,14 @@ func TestLog(t *testing.T) {
 			},
 			ctx: ctxWithSpan,
 			want: map[string]any{
-				"Category":   "Request",
-				"CustomerID": "customerID",
-				"ErrSrc":     "filename",
-				"ErrLine":    123,
-				"CallID":     "callID",
-				"ErrTime":    ti.UTC(),
-				"Type":       "BadRequest",
-				"level":      "ERROR",
-				"TraceID":    tID.String(),
-				"msg":        "something went wrong",
+				"Category": "Request",
+				"ErrSrc":   "filename",
+				"ErrLine":  123,
+				"ErrTime":  ti.UTC(),
+				"Type":     "BadRequest",
+				"level":    "INFO",
+				"TraceID":  tID.String(),
+				"msg":      "something went wrong",
 				"package/path.SQLQueryErr": map[string]any{
 					"Query": "SELECT * FROM users",
 				},
@@ -472,16 +418,14 @@ func TestLog(t *testing.T) {
 				Msg:      ErrTopAttrs("hello"),
 			},
 			want: map[string]any{
-				"Category":   "Request",
-				"CustomerID": "customerID",
-				"ErrSrc":     "filename",
-				"ErrLine":    123,
-				"CallID":     "callID",
-				"ErrTime":    ti.UTC(),
-				"Type":       "BadRequest",
-				"level":      "ERROR",
-				"msg":        "hello",
-				"key":        "value",
+				"Category": "Request",
+				"ErrSrc":   "filename",
+				"ErrLine":  123,
+				"ErrTime":  ti.UTC(),
+				"Type":     "BadRequest",
+				"level":    "INFO",
+				"msg":      "hello",
+				"key":      "value",
 			},
 		},
 		{
@@ -494,10 +438,8 @@ func TestLog(t *testing.T) {
 			),
 			want: map[string]any{
 				"Category":    "Request",
-				"CustomerID":  "customerID",
 				"ErrSrc":      "/Users/blah/trees/github.com/gostdlib/base/errors/errors_test.go",
-				"ErrLine":     489,
-				"CallID":      "callID",
+				"ErrLine":     433,
 				"ErrTime":     ti.UTC(),
 				"Type":        "BadRequest",
 				"level":       "ERROR",
@@ -516,17 +458,15 @@ func TestLog(t *testing.T) {
 				WithAttrs(slog.String("customAttrKey", "customAttrValue"), slog.Int("customAttrNum", 99)),
 			),
 			want: map[string]any{
-				"Category":       "Request",
-				"CustomerID":     "customerID",
-				"ErrSrc":         "/Users/blah/trees/github.com/gostdlib/base/errors/errors_test.go",
-				"ErrLine":        511,
-				"CallID":         "callID",
-				"ErrTime":        ti.UTC(),
-				"Type":           "BadRequest",
-				"level":          "ERROR",
-				"msg":            "something went wrong",
-				"customAttrKey":  "customAttrValue",
-				"customAttrNum":  99,
+				"Category":      "Request",
+				"ErrSrc":        "/Users/blah/trees/github.com/gostdlib/base/errors/errors_test.go",
+				"ErrLine":       453,
+				"ErrTime":       ti.UTC(),
+				"Type":          "BadRequest",
+				"level":         "ERROR",
+				"msg":           "something went wrong",
+				"customAttrKey": "customAttrValue",
+				"customAttrNum": 99,
 			},
 		},
 	}
@@ -539,8 +479,11 @@ func TestLog(t *testing.T) {
 			test.ctx = context.Background()
 		}
 
-		test.e.Log(test.ctx, "callID", "customerID", test.req)
+		test.e.Log(test.ctx)
 
+		if test.want == nil && buff.Len() == 0 {
+			continue
+		}
 		if err := json.Unmarshal(buff.Bytes(), &got); err != nil {
 			t.Logf("got: %s", buff.Bytes())
 			t.Fatalf("TestLog(%s): got error on json.Unmarshal: %s", test.name, err)

--- a/errors/requests.go
+++ b/errors/requests.go
@@ -1,0 +1,129 @@
+package errors
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+
+	"github.com/go-json-experiment/json"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// RequestConversion is a function type that defines how to convert a request object of type T into a string representation.
+// This is intended to be used for logging purposes. If the conversion fails, it should return a string that indicates the
+// failure, rather than an error, as this will be attached to log attributes.
+type RequestConversion func(ctx context.Context, v any) string
+
+// RequestSwitchCase is a struct that holds a reflect.Type and a corresponding RequestConversion function.
+// This allows you to define different conversion strategies for different types of request objects, and switch between them at
+// runtime based on the type of the request.
+type RequestSwitchCase struct {
+	Type       reflect.Type
+	Conversion RequestConversion
+}
+
+// RequestToStr provides a methodology for converting a request object to a string. This allows you to apply it
+// as an attribute value for use in logging.
+type RequestToStr struct {
+	Switch  []RequestSwitchCase
+	Default RequestConversion
+}
+
+// Convert takes a request object and attempts to convert it to a string using the defined RequestSwitches.
+// If no matching type is found, it uses the Default conversion function if provided, or returns a message
+// indicating that no conversion was found.
+func (r *RequestToStr) Convert(ctx context.Context, req any) string {
+	rt := reflect.TypeOf(req)
+	for _, s := range r.Switch {
+		if rt == s.Type || (s.Type.Kind() == reflect.Interface && rt != nil && rt.Implements(s.Type)) {
+			return s.Conversion(ctx, req)
+		}
+	}
+	if r.Default == nil {
+		return fmt.Sprintf("no conversion found for request of type %T", req)
+	}
+	return r.Default(ctx, req)
+}
+
+// ProtoRequestToStr is a RequestConversion function that converts a proto.Message into its JSON string representation.
+func ProtoRequestToStr(ctx context.Context, v any) string {
+	var err error
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Sprintf("ProtoRequestToStr received a non-proto.Message type: %T", v)
+	}
+
+	reqBytes, err := protojson.Marshal(msg)
+	if err != nil {
+		reqBytes = fmt.Appendf(reqBytes, "unable to marshal proto.Message due to error: %s", err)
+	}
+	return bytesToStr(reqBytes)
+}
+
+// HTTPRequestToStr is a RequestConversion function that converts v into its JSON string representation. v must be *http.Request.
+func HTTPRequestToStr(ctx context.Context, v any) string {
+	var err error
+	msg, ok := v.(*http.Request)
+	if !ok {
+		return fmt.Sprintf("HTTPRequestToStr received a non-*http.Request type: %T", v)
+	}
+	reqBytes, err := requestToJSON(msg)
+	if err != nil {
+		reqBytes = fmt.Appendf(reqBytes, "unable to marshal *http.Request due to error: %s", err)
+	}
+	return bytesToStr(reqBytes)
+}
+
+// ObjectToStr is a RequestConversion function that attempts to convert any object into a string representation.
+// It attempts a JSON conversion.
+func ObjectToStr(ctx context.Context, v any) string {
+	reqBytes, err := json.Marshal(v)
+	if err != nil {
+		reqBytes = fmt.Appendf(reqBytes, "unable to marshal request %T object due to error: %s", v, err.Error())
+	}
+	return bytesToStr(reqBytes)
+}
+
+// JSONRequest is a simplified version of http.Request for JSON serialization
+type JSONRequest struct {
+	Method        string              `json:"method"`
+	URL           string              `json:"url"`
+	Header        map[string][]string `json:"header"`
+	ContentLength int64               `json:"content_length"`
+	Host          string              `json:"host"`
+	RemoteAddr    string              `json:"remote_addr"`
+	RequestURI    string              `json:"request_uri"`
+	Body          string              `json:"body"`
+}
+
+func requestToJSON(r *http.Request) ([]byte, error) {
+	var bodyBytes []byte
+	// Read the original body
+	if r.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		r.Body.Close()
+	}
+
+	// Reset the request body so it can be read again
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	jr := JSONRequest{
+		Method:        r.Method,
+		URL:           r.URL.String(),
+		Header:        r.Header,
+		ContentLength: r.ContentLength,
+		Host:          r.Host,
+		RemoteAddr:    r.RemoteAddr,
+		RequestURI:    r.RequestURI,
+		Body:          bytesToStr(bodyBytes),
+	}
+	return json.Marshal(jr)
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -14,6 +14,9 @@ type EOpts struct {
 	StackTrace bool
 	// Attrs are additional attributes to include in the error.
 	Attrs []slog.Attr
+	// LogLevel is the log level to use when logging this error. This defaults to slog.LevelError,
+	// but can be overridden with WithLogLevel().
+	LogLevel slog.Level
 }
 
 // EOption is an optional argument for E().

--- a/rpc/grpc/server/internal/interceptors/internal/converters/converters.go
+++ b/rpc/grpc/server/internal/interceptors/internal/converters/converters.go
@@ -1,0 +1,30 @@
+// Package converters provides types to convert a request into a string representation.
+package converters
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+
+	"github.com/gostdlib/base/errors"
+	"google.golang.org/protobuf/proto"
+)
+
+var requestToStr = errors.RequestToStr{
+	Switch: []errors.RequestSwitchCase{
+		{
+			Type:       reflect.TypeOf((*proto.Message)(nil)).Elem(),
+			Conversion: errors.ProtoRequestToStr,
+		},
+		{
+			Type:       reflect.TypeOf((*http.Request)(nil)),
+			Conversion: errors.HTTPRequestToStr,
+		},
+	},
+	Default: errors.ObjectToStr,
+}
+
+// Request converts a request object into a string representation using the defined RequestToStr.
+func Request(ctx context.Context, req any) string {
+	return requestToStr.Convert(ctx, req)
+}

--- a/rpc/grpc/server/internal/interceptors/internal/converters/converters_test.go
+++ b/rpc/grpc/server/internal/interceptors/internal/converters/converters_test.go
@@ -1,0 +1,64 @@
+package converters
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/gostdlib/base/errors/example/proto"
+)
+
+func TestRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		req      any
+		wantSub  string
+		wantZero bool
+	}{
+		{
+			name:    "Success: nil request returns null",
+			req:     nil,
+			wantSub: "null",
+		},
+		{
+			name:    "Success: proto message converts to JSON",
+			req:     &pb.HelloReq{Name: "world"},
+			wantSub: "world",
+		},
+		{
+			name:    "Success: generic struct uses default conversion",
+			req:     struct{ Foo string }{Foo: "bar"},
+			wantSub: "bar",
+		},
+		{
+			name:    "Success: string uses default conversion",
+			req:     "hello",
+			wantSub: "hello",
+		},
+	}
+
+	for _, test := range tests {
+		result := Request(context.Background(), test.req)
+		if test.wantZero && result != "" {
+			t.Errorf("TestRequest(%s): got %q, want empty string", test.name, result)
+			continue
+		}
+		if test.wantSub != "" && !contains(result, test.wantSub) {
+			t.Errorf("TestRequest(%s): got %q, want substring %q", test.name, result, test.wantSub)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/rpc/grpc/server/internal/interceptors/stream/stream.go
+++ b/rpc/grpc/server/internal/interceptors/stream/stream.go
@@ -2,9 +2,12 @@
 package stream
 
 import (
+	"log/slog"
+
 	"github.com/google/uuid"
 	"github.com/gostdlib/base/context"
 	"github.com/gostdlib/base/errors"
+	"github.com/gostdlib/base/rpc/grpc/server/internal/interceptors/internal/converters"
 
 	grpcContext "github.com/gostdlib/base/context/grpc"
 	"google.golang.org/grpc"
@@ -69,18 +72,31 @@ func New(ctx context.Context, errConvert ErrConvert, options ...Options) (*Inter
 }
 
 // Intercept is a grpc.StreamServerInterceptor that wraps the provided interceptors.
-func (s *Interceptor) Intercept(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func (s *Interceptor) Intercept(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	grpcMeta := grpcContext.Metadata{CallID: mustUUID().String(), Op: info.FullMethod}
 	md, ok := metadata.FromIncomingContext(ss.Context())
 	if ok {
-		id := md.Get("customerID")
+		if len(md.Get("CallID")) != 0 {
+			grpcMeta.CustomerID = md.Get("CallID")[0]
+		}
+		id := md.Get("CustomerID")
 		if len(id) == 1 {
 			grpcMeta.CustomerID = id[0]
 		}
 	}
 
+	ctx := ss.Context()
+	ctx = context.AddAttrs(
+		ctx,
+		slog.String("CallID", grpcMeta.CallID),
+		slog.String("Op", grpcMeta.Op),
+	)
+	if grpcMeta.CustomerID != "" {
+		ctx = context.AddAttrs(ctx, slog.String("CustomerID", grpcMeta.CustomerID))
+	}
+
 	wrapped := &streamWrap{
-		ctx:          context.Attach(ss.Context()),
+		ctx:          context.Attach(ctx),
 		md:           grpcMeta,
 		intercepts:   s.intercepts,
 		errConvert:   s.errConvert,
@@ -104,7 +120,7 @@ type streamWrap struct {
 // SendMsg is a wrapper around the SendMsg method of the grpc.ServerStream. It calls all the
 // intercepts in the order they were added. If any of the intercepts return an error, it
 // aborts the call and returns the error.
-func (s *streamWrap) SendMsg(m interface{}) error {
+func (s *streamWrap) SendMsg(m any) error {
 	for _, i := range s.intercepts {
 		if err := i.Send(s.ctx, s.md, s.ServerStream, m); err != nil {
 			return s.errLogAndConvert(s.ctx, nil, err, s.md)
@@ -135,27 +151,21 @@ func (s *streamWrap) RecvMsg(m any) error {
 }
 
 func (s *streamWrap) errLogAndConvert(ctx context.Context, req any, err error, md grpcContext.Metadata) error {
+	ctx = context.AddAttrs(ctx, slog.String("Request", converters.Request(ctx, req)))
+
 	var e errors.Error
-	var ok bool
-	if e, ok = err.(errors.Error); ok {
-		e.Log(ctx, md.CallID, md.CustomerID, req)
-		if s.errConvert != nil {
-			status, err := s.errConvert(ctx, e, md)
-			if err != nil {
-				return err
-			}
-			return status.Err()
-		}
-		return e
-	} else {
+	switch v := err.(type) {
+	case errors.Error:
+		e = v
+	default:
 		e = errors.E(ctx, nil, nil, err)
 	}
 
-	e.Log(ctx, md.CallID, md.CustomerID, req)
+	e.Log(ctx)
 	if s.errConvert != nil {
-		status, err := s.errConvert(ctx, e, md)
-		if err != nil {
-			return err
+		status, cErr := s.errConvert(ctx, e, md)
+		if cErr != nil {
+			return cErr
 		}
 		return status.Err()
 	}

--- a/rpc/grpc/server/internal/interceptors/stream/stream.go
+++ b/rpc/grpc/server/internal/interceptors/stream/stream.go
@@ -77,7 +77,7 @@ func (s *Interceptor) Intercept(srv any, ss grpc.ServerStream, info *grpc.Stream
 	md, ok := metadata.FromIncomingContext(ss.Context())
 	if ok {
 		if len(md.Get("CallID")) != 0 {
-			grpcMeta.CustomerID = md.Get("CallID")[0]
+			grpcMeta.CallID = md.Get("CallID")[0]
 		}
 		id := md.Get("CustomerID")
 		if len(id) == 1 {
@@ -165,7 +165,9 @@ func (s *streamWrap) errLogAndConvert(ctx context.Context, req any, err error, m
 	if s.errConvert != nil {
 		status, cErr := s.errConvert(ctx, e, md)
 		if cErr != nil {
-			return cErr
+			ce := errors.E(ctx, nil, nil, cErr)
+			ce.Log(ctx)
+			return e
 		}
 		return status.Err()
 	}

--- a/rpc/grpc/server/internal/interceptors/stream/stream_test.go
+++ b/rpc/grpc/server/internal/interceptors/stream/stream_test.go
@@ -169,6 +169,7 @@ func TestInterceptMetadata(t *testing.T) {
 		name           string
 		incomingMD     metadata.MD
 		wantCustomerID string
+		wantCallID     string
 	}{
 		{
 			name:           "Success: CustomerID extracted from metadata",
@@ -181,14 +182,16 @@ func TestInterceptMetadata(t *testing.T) {
 			wantCustomerID: "",
 		},
 		{
-			name:           "Success: CallID overridden by CustomerID",
-			incomingMD:     metadata.Pairs("CallID", "call-1", "CustomerID", "cust-99"),
-			wantCustomerID: "cust-99",
+			name:           "Success: CallID does not affect CustomerID",
+			incomingMD:     metadata.Pairs("CallID", "call-1"),
+			wantCustomerID: "",
+			wantCallID:     "call-1",
 		},
 		{
-			name:           "Success: CallID used when no CustomerID",
-			incomingMD:     metadata.Pairs("CallID", "call-1"),
-			wantCustomerID: "call-1",
+			name:           "Success: CustomerID extracted even when CallID present",
+			incomingMD:     metadata.Pairs("CallID", "call-1", "CustomerID", "cust-99"),
+			wantCustomerID: "cust-99",
+			wantCallID:     "call-1",
 		},
 	}
 
@@ -227,6 +230,9 @@ func TestInterceptMetadata(t *testing.T) {
 		}
 		if capturedMD.CallID == "" {
 			t.Errorf("TestInterceptMetadata(%s): CallID: got empty, want non-empty", test.name)
+		}
+		if test.wantCallID != "" && capturedMD.CallID != test.wantCallID {
+			t.Errorf("TestInterceptMetadata(%s): CallID: got %q, want %q", test.name, capturedMD.CallID, test.wantCallID)
 		}
 	}
 }

--- a/rpc/grpc/server/internal/interceptors/stream/stream_test.go
+++ b/rpc/grpc/server/internal/interceptors/stream/stream_test.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gostdlib/base/context"
@@ -79,24 +80,30 @@ func TestStreamInterceptor(t *testing.T) {
 		incomingMD  metadata.MD
 	}{
 		{
-			name:        "Intercept send error",
+			name:        "Error: intercept send error",
 			intercepts:  []Intercept{&testIntercept{sendErr: errors.New("send error")}},
 			wantSendErr: true,
 			customerID:  "12345",
-			incomingMD:  metadata.Pairs("customerID", "12345"),
+			incomingMD:  metadata.Pairs("CustomerID", "12345"),
 		},
 		{
-			name:        "Intercept recv error",
+			name:        "Error: intercept recv error",
 			intercepts:  []Intercept{&testIntercept{recvErr: errors.New("recv error")}},
 			wantRecvErr: true,
 			customerID:  "12345",
-			incomingMD:  metadata.Pairs("customerID", "12345"),
+			incomingMD:  metadata.Pairs("CustomerID", "12345"),
 		},
 		{
-			name:       "Successful send and recv",
+			name:       "Success: send and recv",
 			intercepts: []Intercept{&testIntercept{}},
 			customerID: "12345",
-			incomingMD: metadata.Pairs("customerID", "12345"),
+			incomingMD: metadata.Pairs("CustomerID", "12345"),
+		},
+		{
+			name:       "Success: no metadata",
+			intercepts: []Intercept{&testIntercept{}},
+			customerID: "",
+			incomingMD: metadata.MD{},
 		},
 	}
 
@@ -151,6 +158,297 @@ func TestStreamInterceptor(t *testing.T) {
 		)
 		if err != nil && !(test.wantSendErr || test.wantRecvErr) {
 			t.Errorf("TestStreamInterceptor(%s): got err != nil, want err == nil", test.name)
+		}
+	}
+}
+
+func TestInterceptMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		incomingMD     metadata.MD
+		wantCustomerID string
+	}{
+		{
+			name:           "Success: CustomerID extracted from metadata",
+			incomingMD:     metadata.Pairs("CustomerID", "cust-42"),
+			wantCustomerID: "cust-42",
+		},
+		{
+			name:           "Success: no CustomerID in metadata",
+			incomingMD:     metadata.MD{},
+			wantCustomerID: "",
+		},
+		{
+			name:           "Success: CallID overridden by CustomerID",
+			incomingMD:     metadata.Pairs("CallID", "call-1", "CustomerID", "cust-99"),
+			wantCustomerID: "cust-99",
+		},
+		{
+			name:           "Success: CallID used when no CustomerID",
+			incomingMD:     metadata.Pairs("CallID", "call-1"),
+			wantCustomerID: "call-1",
+		},
+	}
+
+	for _, test := range tests {
+		var capturedMD grpcContext.Metadata
+
+		ctx := metadata.NewIncomingContext(context.Background(), test.incomingMD)
+		fss := &fakeServerStream{
+			ctx:     ctx,
+			sendMsg: func(m interface{}) error { return nil },
+			recvMsg: func(m interface{}) error { return nil },
+		}
+
+		intercept := &metadataCapture{captured: &capturedMD}
+		interceptor, err := New(ctx, nil, WithIntercepts(intercept))
+		if err != nil {
+			t.Fatalf("TestInterceptMetadata(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		handler := func(srv interface{}, stream grpc.ServerStream) error {
+			msg := &pb.HelloReq{Name: "test"}
+			return stream.SendMsg(msg)
+		}
+
+		err = interceptor.Intercept(nil, fss, &grpc.StreamServerInfo{FullMethod: "/service/method"}, handler)
+		if err != nil {
+			t.Errorf("TestInterceptMetadata(%s): got err == %s, want err == nil", test.name, err)
+			continue
+		}
+
+		if capturedMD.CustomerID != test.wantCustomerID {
+			t.Errorf("TestInterceptMetadata(%s): CustomerID: got %q, want %q", test.name, capturedMD.CustomerID, test.wantCustomerID)
+		}
+		if capturedMD.Op != "/service/method" {
+			t.Errorf("TestInterceptMetadata(%s): Op: got %q, want %q", test.name, capturedMD.Op, "/service/method")
+		}
+		if capturedMD.CallID == "" {
+			t.Errorf("TestInterceptMetadata(%s): CallID: got empty, want non-empty", test.name)
+		}
+	}
+}
+
+type metadataCapture struct {
+	captured *grpcContext.Metadata
+}
+
+func (m *metadataCapture) Send(ctx context.Context, md grpcContext.Metadata, ss grpc.ServerStream, msg any) error {
+	*m.captured = md
+	return nil
+}
+
+func (m *metadataCapture) Recv(ctx context.Context, md grpcContext.Metadata, msg any) error {
+	*m.captured = md
+	return nil
+}
+
+func TestStreamErrLogAndConvert(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sendErr    error
+		errConvert ErrConvert
+		wantErr    bool
+	}{
+		{
+			name:    "Error: errors.Error without converter",
+			sendErr: errors.New("send failed"),
+			wantErr: true,
+		},
+		{
+			name:    "Error: errors.Error with converter",
+			sendErr: errors.New("send failed"),
+			errConvert: func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+				return status.New(codespkg.Internal, e.Error()), nil
+			},
+			wantErr: true,
+		},
+		{
+			name:    "Error: errors.Error with failing converter",
+			sendErr: errors.New("send failed"),
+			errConvert: func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+				return nil, fmt.Errorf("conversion failed")
+			},
+			wantErr: true,
+		},
+		{
+			name:    "Error: standard error without converter",
+			sendErr: fmt.Errorf("plain error"),
+			wantErr: true,
+		},
+		{
+			name:    "Error: standard error with converter",
+			sendErr: fmt.Errorf("plain error"),
+			errConvert: func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+				return status.New(codespkg.Unknown, e.Error()), nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("CustomerID", "12345"))
+		fss := &fakeServerStream{
+			ctx: ctx,
+			sendMsg: func(m interface{}) error {
+				return test.sendErr
+			},
+			recvMsg: func(m interface{}) error { return nil },
+		}
+
+		interceptor, err := New(ctx, test.errConvert)
+		if err != nil {
+			t.Fatalf("TestStreamErrLogAndConvert(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		handler := func(srv interface{}, stream grpc.ServerStream) error {
+			return stream.SendMsg(&pb.HelloReq{Name: "test"})
+		}
+
+		err = interceptor.Intercept(nil, fss, &grpc.StreamServerInfo{FullMethod: "/service/method"}, handler)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestStreamErrLogAndConvert(%s): got err == nil, want err != nil", test.name)
+		case err != nil && !test.wantErr:
+			t.Errorf("TestStreamErrLogAndConvert(%s): got err == %s, want err == nil", test.name, err)
+		}
+	}
+}
+
+func TestStreamMultipleIntercepts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		intercepts  []Intercept
+		wantSendErr bool
+		wantRecvErr bool
+	}{
+		{
+			name: "Success: multiple intercepts all pass",
+			intercepts: []Intercept{
+				&testIntercept{},
+				&testIntercept{},
+				&testIntercept{},
+			},
+		},
+		{
+			name: "Error: second send intercept fails",
+			intercepts: []Intercept{
+				&testIntercept{},
+				&testIntercept{sendErr: errors.New("second fails")},
+				&testIntercept{},
+			},
+			wantSendErr: true,
+		},
+		{
+			name: "Error: second recv intercept fails",
+			intercepts: []Intercept{
+				&testIntercept{},
+				&testIntercept{recvErr: errors.New("second fails")},
+				&testIntercept{},
+			},
+			wantRecvErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("CustomerID", "12345"))
+		fss := &fakeServerStream{
+			ctx:     ctx,
+			sendMsg: func(m interface{}) error { return nil },
+			recvMsg: func(m interface{}) error { return nil },
+		}
+
+		interceptor, err := New(ctx, nil, WithIntercepts(test.intercepts...))
+		if err != nil {
+			t.Fatalf("TestStreamMultipleIntercepts(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		handler := func(srv any, stream grpc.ServerStream) error {
+			msg := &pb.HelloReq{Name: "test"}
+
+			err := stream.SendMsg(msg)
+			switch {
+			case err == nil && test.wantSendErr:
+				t.Errorf("TestStreamMultipleIntercepts(%s)(send): got err == nil, want err != nil", test.name)
+				return nil
+			case err != nil && !test.wantSendErr:
+				t.Errorf("TestStreamMultipleIntercepts(%s)(send): got err == %s, want err == nil", test.name, err)
+				return nil
+			case err != nil:
+				return nil
+			}
+
+			err = stream.RecvMsg(msg)
+			switch {
+			case err == nil && test.wantRecvErr:
+				t.Errorf("TestStreamMultipleIntercepts(%s)(recv): got err == nil, want err != nil", test.name)
+			case err != nil && !test.wantRecvErr:
+				t.Errorf("TestStreamMultipleIntercepts(%s)(recv): got err == %s, want err == nil", test.name, err)
+			}
+			return nil
+		}
+
+		err = interceptor.Intercept(nil, fss, &grpc.StreamServerInfo{FullMethod: "/service/method"}, handler)
+		if err != nil && !(test.wantSendErr || test.wantRecvErr) {
+			t.Errorf("TestStreamMultipleIntercepts(%s): got err != nil, want err == nil", test.name)
+		}
+	}
+}
+
+func TestStreamRecvMsgError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		recvErr    error
+		errConvert ErrConvert
+		wantErr    bool
+	}{
+		{
+			name:    "Error: underlying stream recv fails",
+			recvErr: fmt.Errorf("stream recv error"),
+			wantErr: true,
+		},
+		{
+			name:    "Error: underlying stream recv fails with converter",
+			recvErr: fmt.Errorf("stream recv error"),
+			errConvert: func(ctx context.Context, e errors.Error, meta grpcContext.Metadata) (*status.Status, error) {
+				return status.New(codespkg.Unavailable, e.Error()), nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("CustomerID", "12345"))
+		fss := &fakeServerStream{
+			ctx:     ctx,
+			sendMsg: func(m any) error { return nil },
+			recvMsg: func(m any) error { return test.recvErr },
+		}
+
+		interceptor, err := New(ctx, test.errConvert)
+		if err != nil {
+			t.Fatalf("TestStreamRecvMsgError(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		handler := func(srv any, stream grpc.ServerStream) error {
+			msg := &pb.HelloReq{Name: "test"}
+			return stream.RecvMsg(msg)
+		}
+
+		err = interceptor.Intercept(nil, fss, &grpc.StreamServerInfo{FullMethod: "/service/method"}, handler)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestStreamRecvMsgError(%s): got err == nil, want err != nil", test.name)
+		case err != nil && !test.wantErr:
+			t.Errorf("TestStreamRecvMsgError(%s): got err == %s, want err == nil", test.name, err)
 		}
 	}
 }

--- a/rpc/grpc/server/internal/interceptors/unary/unary.go
+++ b/rpc/grpc/server/internal/interceptors/unary/unary.go
@@ -1,9 +1,12 @@
 package unary
 
 import (
+	"log/slog"
+
 	"github.com/google/uuid"
 	"github.com/gostdlib/base/context"
 	"github.com/gostdlib/base/errors"
+	"github.com/gostdlib/base/rpc/grpc/server/internal/interceptors/internal/converters"
 	"github.com/gostdlib/base/telemetry/otel/trace/span"
 
 	grpcContext "github.com/gostdlib/base/context/grpc"
@@ -90,12 +93,17 @@ func (u *Interceptor) attachMeta(ctx context.Context, req any, info *grpc.UnaryS
 	grpcMeta := grpcContext.Metadata{CallID: mustUUID().String(), Op: info.FullMethod}
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		id := md.Get("customerID")
+		if len(md.Get("CallID")) != 0 {
+			grpcMeta.CustomerID = md.Get("CallID")[0]
+		}
+		id := md.Get("CustomerID")
 		if len(id) == 1 {
 			grpcMeta.CustomerID = id[0]
 		}
 	}
-	ctx = context.Attach(grpcContext.SetMetadata(ctx, grpcMeta))
+	ctx = context.Attach(
+		grpcContext.SetMetadata(ctx, grpcMeta),
+	)
 
 	return handler(ctx, req)
 }
@@ -109,14 +117,24 @@ func (u *Interceptor) errLogAndConvert(ctx context.Context, req any, info *grpc.
 	}
 
 	md := grpcContext.GetMetadata(ctx)
+	if md.CallID == "" {
+		ctx = context.AddAttrs(ctx, slog.String("CallID", mustUUID().String()))
+	}
+	if md.CustomerID != "" {
+		ctx = context.AddAttrs(ctx, slog.String("CustomerID", md.CustomerID))
+	}
+	if md.Op != "" {
+		ctx = context.AddAttrs(ctx, slog.String("Op", md.Op))
+	}
+	ctx = context.AddAttrs(ctx, slog.String("Request", converters.Request(ctx, req)))
 
 	if e, ok := err.(errors.Error); ok {
-		e.Log(ctx, md.CallID, md.CustomerID, req)
+		e.Log(ctx)
 		if u.errConvert != nil {
 			status, cErr := u.errConvert(ctx, e, md)
 			if cErr != nil {
 				ce := errors.E(ctx, nil, nil, cErr)
-				ce.Log(ctx, md.CallID, md.CustomerID, req)
+				ce.Log(ctx)
 				return nil, e
 			}
 			return nil, status.Err()
@@ -124,7 +142,7 @@ func (u *Interceptor) errLogAndConvert(ctx context.Context, req any, info *grpc.
 		return nil, e
 	}
 	e := errors.E(ctx, nil, nil, err)
-	e.Log(ctx, md.CallID, md.CustomerID, req)
+	e.Log(ctx)
 	return nil, e
 }
 

--- a/rpc/grpc/server/internal/interceptors/unary/unary.go
+++ b/rpc/grpc/server/internal/interceptors/unary/unary.go
@@ -94,7 +94,7 @@ func (u *Interceptor) attachMeta(ctx context.Context, req any, info *grpc.UnaryS
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		if len(md.Get("CallID")) != 0 {
-			grpcMeta.CustomerID = md.Get("CallID")[0]
+			grpcMeta.CallID = md.Get("CallID")[0]
 		}
 		id := md.Get("CustomerID")
 		if len(id) == 1 {

--- a/rpc/grpc/server/internal/interceptors/unary/unary_test.go
+++ b/rpc/grpc/server/internal/interceptors/unary/unary_test.go
@@ -1,7 +1,6 @@
 package unary
 
 import (
-	stdErr "errors"
 	"fmt"
 	"testing"
 
@@ -117,12 +116,9 @@ func TestIntercept(t *testing.T) {
 			continue
 		}
 		if err != nil {
-			if !stdErr.Is(err, errors.Error{}) {
+			if _, ok := err.(errors.Error); !ok {
 				t.Errorf("TestUnaryIntercept(%s): expected error to be of type errors.Error, got %T", test.name, err)
 				continue
-			}
-			if err.Error() != test.wantErr.Error() {
-				t.Errorf("TestUnaryIntercept(%s): expected error %v, got %v", test.name, test.wantErr, err)
 			}
 			continue
 		}

--- a/rpc/grpc/server/internal/interceptors/unary/unary_test.go
+++ b/rpc/grpc/server/internal/interceptors/unary/unary_test.go
@@ -58,38 +58,57 @@ func TestIntercept(t *testing.T) {
 		name       string
 		ctx        context.Context
 		handler    grpc.UnaryHandler
-		wantErr    error
+		wantErr    bool
 		customerID string
+		wantCallID string
 	}{
 		{
-			name: "Valid metadata and successful handler",
+			name: "Success: valid metadata and successful handler",
 			ctx:  metadata.NewIncomingContext(context.Background(), metadata.Pairs("customerID", "12345")),
 			handler: func(ctx context.Context, req any) (any, error) {
 				resultCtx = ctx
 				return "response", nil
 			},
-			wantErr:    nil,
 			customerID: "12345",
 		},
 		{
-			name: "No metadata",
+			name: "Success: no metadata",
 			ctx:  context.Background(),
 			handler: func(ctx context.Context, req any) (any, error) {
 				resultCtx = ctx
 				return "response", nil
 			},
-			wantErr:    nil,
 			customerID: "",
 		},
 		{
-			name: "Handler returns error",
+			name: "Error: handler returns error",
 			ctx:  metadata.NewIncomingContext(context.Background(), metadata.Pairs("customerID", "12345")),
 			handler: func(ctx context.Context, req any) (any, error) {
 				resultCtx = ctx
 				return nil, status.Error(13, "handler error")
 			},
-			wantErr:    status.Error(13, "handler error"),
+			wantErr:    true,
 			customerID: "12345",
+		},
+		{
+			name: "Success: CallID does not affect CustomerID",
+			ctx:  metadata.NewIncomingContext(context.Background(), metadata.Pairs("CallID", "call-1")),
+			handler: func(ctx context.Context, req any) (any, error) {
+				resultCtx = ctx
+				return "response", nil
+			},
+			customerID: "",
+			wantCallID: "call-1",
+		},
+		{
+			name: "Success: CustomerID extracted even when CallID present",
+			ctx:  metadata.NewIncomingContext(context.Background(), metadata.Pairs("CallID", "call-1", "CustomerID", "cust-99")),
+			handler: func(ctx context.Context, req any) (any, error) {
+				resultCtx = ctx
+				return "response", nil
+			},
+			customerID: "cust-99",
+			wantCallID: "call-1",
 		},
 	}
 
@@ -108,17 +127,15 @@ func TestIntercept(t *testing.T) {
 		_, err = unary.Intercept(test.ctx, req, info, test.handler)
 
 		switch {
-		case err == nil && test.wantErr != nil:
+		case err == nil && test.wantErr:
 			t.Errorf("TestUnaryIntercept(%s): got err == nil, want err != nil", test.name)
 			continue
-		case err != nil && test.wantErr == nil:
-			t.Errorf("TestUnaryIntercept(%s): got err != nil, want err == nil", test.name)
+		case err != nil && !test.wantErr:
+			t.Errorf("TestUnaryIntercept(%s): got err == %s, want err == nil", test.name, err)
 			continue
-		}
-		if err != nil {
+		case err != nil:
 			if _, ok := err.(errors.Error); !ok {
-				t.Errorf("TestUnaryIntercept(%s): expected error to be of type errors.Error, got %T", test.name, err)
-				continue
+				t.Errorf("TestUnaryIntercept(%s): got err type %T, want errors.Error", test.name, err)
 			}
 			continue
 		}
@@ -132,6 +149,9 @@ func TestIntercept(t *testing.T) {
 		}
 		if gMeta.CallID == "" {
 			t.Errorf("TestUnaryIntercept(%s): callID: got empty, want non-empty", test.name)
+		}
+		if test.wantCallID != "" && gMeta.CallID != test.wantCallID {
+			t.Errorf("TestUnaryIntercept(%s): callID: got %q, want %q", test.name, gMeta.CallID, test.wantCallID)
 		}
 	}
 }


### PR DESCRIPTION
This pull request refactors and simplifies the error handling and logging system in the `errors` package. The main changes include removing request serialization from the logging logic, introducing new fields and options for error customization, and improving the semantics of error comparison. The test suite is updated accordingly to reflect these changes.

**Error struct and options enhancements:**

- Added `LogLevel` field to `Error` to allow specifying the log level for each error, with a new `WithLogLevel` option for customization. [[1]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13R265-R272) [[2]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13R319-R328) [[3]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13L325-R337) [[4]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13L363-R375)
- Introduced `IsFunc` field to `Error` to allow custom logic for error comparison, and updated the `Is` method to use it if provided. [[1]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13R265-R272) [[2]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13L381-R409)
- Added `IsZero` method to determine if an `Error` is a zero value.

**Logging and serialization changes:**

- Simplified the `Log` method: removed request serialization (including special handling for HTTP and protobuf requests), and now only logs error attributes and context attributes.
- Removed unused imports and code related to request and proto serialization. [[1]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13L176-L183) [[2]](diffhunk://#diff-d04adb084335cede75155605abdcc0bef92c45a740b274f985f378e955c81a13L198-L202) [[3]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L10) [[4]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L26-L27)

**Error comparison logic:**

- Changed the semantics of the `Is` method: an error with nil category and type no longer matches all errors, preventing accidental broad matches.
- Updated tests to reflect the new comparison logic.

**Test updates:**

- Updated tests to remove request/proto logging checks, align with new log output, and verify `LogLevel` and error attribute handling. [[1]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8R129) [[2]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8R149) [[3]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L342-R364) [[4]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L426-R381) [[5]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L450-R402) [[6]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L476-R426) [[7]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L497-R442) [[8]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L520-R463) [[9]](diffhunk://#diff-5a256ba4448e51ae85f5cdae75f5093675bc7ea190d00bcf687fffa782822ca8L542-R486)

These changes make error handling more flexible and logging more focused, while removing unnecessary complexity from request serialization.