### PR TITLE
Minor speed ups

### DIFF
--- a/concurrency/sync/group.go
+++ b/concurrency/sync/group.go
@@ -121,9 +121,10 @@ type Group struct {
 	errors Errors
 	wg     sync.WaitGroup
 
-	start    time.Time
-	otelOnce sync.Once
-	span     span.Span
+	start       time.Time
+	otelOnce    sync.Once
+	span        span.Span
+	isRecording bool
 
 	noCopy noCopy // Flag govet to prevent copying
 
@@ -142,6 +143,7 @@ type Group struct {
 func (w *Group) reset() {
 	w.start = time.Time{}
 	w.otelOnce = sync.Once{}
+	w.isRecording = false
 	w.count.Store(0)
 	w.total.Store(0)
 	w.CancelOnErr = nil
@@ -191,20 +193,19 @@ func (w *Group) Go(ctx context.Context, f func(ctx context.Context) error, optio
 
 	var didOnce bool
 	// This sets up a new child span where all execution will be recorded.
-	// This is done once per Group until the Group is reset.s
+	// This is done once per Group until the Group is reset.
 	w.otelOnce.Do(func() {
 		spanner := span.Get(ctx)
 		if spanner.IsRecording() {
 			w.start = time.Now().UTC()
 			ctx, w.span = span.New(ctx, span.WithName("github.com/gostdlib/base/concurrency/sync.Group"))
+			w.isRecording = true
 		}
 		didOnce = true
 	})
 	// Since this wasn't the initial setup, we need to attach the span to the context.
-	if !didOnce {
-		if span.Get(ctx).IsRecording() {
-			ctx = otelTrace.ContextWithSpan(ctx, w.span.Span)
-		}
+	if !didOnce && w.isRecording {
+		ctx = otelTrace.ContextWithSpan(ctx, w.span.Span)
 	}
 
 	w.execute(ctx, f, opts)

--- a/concurrency/sync/pool.go
+++ b/concurrency/sync/pool.go
@@ -128,16 +128,18 @@ func NewPool[T any](ctx context.Context, name string, n func() T, options ...Opt
 		log.Default().Error(fmt.Sprintf("sync.NewPool(%s): %s", name, err))
 	}
 
-	// Probe once whether T implements Resetter so Put() can skip the type assertion
-	// for non-Resetter types.
-	var isResetter bool
-	if _, ok := any(n()).(Resetter); ok {
-		isResetter = true
-	}
-
 	// When T is an interface, different concrete values may or may not implement Resetter,
 	// so Put() must use a guarded type assertion instead of an unconditional one.
 	isInterface := reflect.TypeFor[T]().Kind() == reflect.Interface
+
+	// Probe once whether T implements Resetter so Put() can skip the type assertion
+	// for non-Resetter types. Use a zero value to avoid calling n() which could
+	// allocate resources or trigger side effects.
+	var isResetter bool
+	if !isInterface {
+		var zero T
+		_, isResetter = any(zero).(Resetter)
+	}
 
 	p := Pool[T]{
 		buffer:          c,

--- a/concurrency/sync/pool.go
+++ b/concurrency/sync/pool.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"runtime"
 	"sync"
 
@@ -35,7 +36,8 @@ type Pool[T any] struct {
 
 	buffer chan T
 
-	isResetter bool
+	isResetter  bool
+	isInterface bool
 
 	getCalls, putCalls, newAllocated, bufferAllocated metric.Int64Counter
 
@@ -133,9 +135,14 @@ func NewPool[T any](ctx context.Context, name string, n func() T, options ...Opt
 		isResetter = true
 	}
 
+	// When T is an interface, different concrete values may or may not implement Resetter,
+	// so Put() must use a guarded type assertion instead of an unconditional one.
+	isInterface := reflect.TypeFor[T]().Kind() == reflect.Interface
+
 	p := Pool[T]{
 		buffer:          c,
 		isResetter:      isResetter,
+		isInterface:     isInterface,
 		getCalls:        gc,
 		putCalls:        pc,
 		newAllocated:    na,
@@ -177,7 +184,11 @@ func (p *Pool[T]) Put(ctx context.Context, v T) {
 		p.putCalls.Add(ctx, 1)
 	}
 
-	if p.isResetter {
+	if p.isInterface {
+		if r, ok := any(v).(Resetter); ok {
+			r.Reset()
+		}
+	} else if p.isResetter {
 		any(v).(Resetter).Reset()
 	}
 

--- a/concurrency/sync/pool.go
+++ b/concurrency/sync/pool.go
@@ -35,6 +35,8 @@ type Pool[T any] struct {
 
 	buffer chan T
 
+	isResetter bool
+
 	getCalls, putCalls, newAllocated, bufferAllocated metric.Int64Counter
 
 	_ sync.Mutex // Unused on purpose, for CopyLocks error
@@ -124,8 +126,16 @@ func NewPool[T any](ctx context.Context, name string, n func() T, options ...Opt
 		log.Default().Error(fmt.Sprintf("sync.NewPool(%s): %s", name, err))
 	}
 
+	// Probe once whether T implements Resetter so Put() can skip the type assertion
+	// for non-Resetter types.
+	var isResetter bool
+	if _, ok := any(n()).(Resetter); ok {
+		isResetter = true
+	}
+
 	p := Pool[T]{
 		buffer:          c,
+		isResetter:      isResetter,
 		getCalls:        gc,
 		putCalls:        pc,
 		newAllocated:    na,
@@ -167,8 +177,8 @@ func (p *Pool[T]) Put(ctx context.Context, v T) {
 		p.putCalls.Add(ctx, 1)
 	}
 
-	if r, ok := any(v).(Resetter); ok {
-		r.Reset()
+	if p.isResetter {
+		any(v).(Resetter).Reset()
 	}
 
 	select {

--- a/concurrency/sync/pool_test.go
+++ b/concurrency/sync/pool_test.go
@@ -32,6 +32,85 @@ func TestPool(t *testing.T) {
 	)
 }
 
+// nonResetter is a concrete type that does NOT implement Resetter.
+type nonResetter struct {
+	val int
+}
+
+func TestPoolPutReset(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name    string
+		fn      func(t *testing.T)
+	}{
+		{
+			name: "Success: Pool[Resetter] calls Reset on concrete Resetter",
+			fn: func(t *testing.T) {
+				p := NewPool[Resetter](ctx, "", func() Resetter { var x intType; return &x }, WithBuffer(1))
+				v := p.Get(ctx).(*intType)
+				*v = 42
+				p.Put(ctx, v)
+				got := p.Get(ctx).(*intType)
+				if *got != 0 {
+					t.Errorf("TestPoolPutReset(%s): got %d, want 0", "Success: Pool[Resetter] calls Reset on concrete Resetter", *got)
+				}
+			},
+		},
+		{
+			name: "Success: Pool[any] does not panic for non-Resetter value",
+			fn: func(t *testing.T) {
+				p := NewPool[any](ctx, "", func() any { return &nonResetter{} }, WithBuffer(1))
+				v := p.Get(ctx).(*nonResetter)
+				v.val = 99
+				p.Put(ctx, v)
+				got := p.Get(ctx).(*nonResetter)
+				if got.val != 99 {
+					t.Errorf("TestPoolPutReset(%s): got val == %d, want 99", "Success: Pool[any] does not panic for non-Resetter value", got.val)
+				}
+			},
+		},
+		{
+			name: "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged",
+			fn: func(t *testing.T) {
+				p := NewPool[any](ctx, "", func() any { var x intType; return &x }, WithBuffer(2))
+				r := p.Get(ctx).(*intType)
+				*r = 10
+				p.Put(ctx, r)
+				nr := &nonResetter{val: 77}
+				p.Put(ctx, nr)
+
+				var sawReset, sawNonResetter bool
+				for i := 0; i < 2; i++ {
+					v := p.Get(ctx)
+					switch x := v.(type) {
+					case *intType:
+						if *x != 0 {
+							t.Errorf("TestPoolPutReset(%s): Resetter value not reset: got %d, want 0", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged", *x)
+						}
+						sawReset = true
+					case *nonResetter:
+						if x.val != 77 {
+							t.Errorf("TestPoolPutReset(%s): nonResetter value changed: got %d, want 77", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged", x.val)
+						}
+						sawNonResetter = true
+					}
+				}
+				if !sawReset {
+					t.Errorf("TestPoolPutReset(%s): never saw Resetter value", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged")
+				}
+				if !sawNonResetter {
+					t.Errorf("TestPoolPutReset(%s): never saw nonResetter value", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test.fn(t)
+	}
+}
+
 func TestCleanup(t *testing.T) {
 	ctx := context.Background()
 

--- a/concurrency/sync/pool_test.go
+++ b/concurrency/sync/pool_test.go
@@ -41,38 +41,38 @@ func TestPoolPutReset(t *testing.T) {
 	ctx := t.Context()
 
 	tests := []struct {
-		name    string
-		fn      func(t *testing.T)
+		name string
+		fn   func(t *testing.T, name string)
 	}{
 		{
 			name: "Success: Pool[Resetter] calls Reset on concrete Resetter",
-			fn: func(t *testing.T) {
+			fn: func(t *testing.T, name string) {
 				p := NewPool[Resetter](ctx, "", func() Resetter { var x intType; return &x }, WithBuffer(1))
 				v := p.Get(ctx).(*intType)
 				*v = 42
 				p.Put(ctx, v)
 				got := p.Get(ctx).(*intType)
 				if *got != 0 {
-					t.Errorf("TestPoolPutReset(%s): got %d, want 0", "Success: Pool[Resetter] calls Reset on concrete Resetter", *got)
+					t.Errorf("TestPoolPutReset(%s): got %d, want 0", name, *got)
 				}
 			},
 		},
 		{
 			name: "Success: Pool[any] does not panic for non-Resetter value",
-			fn: func(t *testing.T) {
+			fn: func(t *testing.T, name string) {
 				p := NewPool[any](ctx, "", func() any { return &nonResetter{} }, WithBuffer(1))
 				v := p.Get(ctx).(*nonResetter)
 				v.val = 99
 				p.Put(ctx, v)
 				got := p.Get(ctx).(*nonResetter)
 				if got.val != 99 {
-					t.Errorf("TestPoolPutReset(%s): got val == %d, want 99", "Success: Pool[any] does not panic for non-Resetter value", got.val)
+					t.Errorf("TestPoolPutReset(%s): got val == %d, want 99", name, got.val)
 				}
 			},
 		},
 		{
 			name: "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged",
-			fn: func(t *testing.T) {
+			fn: func(t *testing.T, name string) {
 				p := NewPool[any](ctx, "", func() any { var x intType; return &x }, WithBuffer(2))
 				r := p.Get(ctx).(*intType)
 				*r = 10
@@ -86,28 +86,28 @@ func TestPoolPutReset(t *testing.T) {
 					switch x := v.(type) {
 					case *intType:
 						if *x != 0 {
-							t.Errorf("TestPoolPutReset(%s): Resetter value not reset: got %d, want 0", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged", *x)
+							t.Errorf("TestPoolPutReset(%s): Resetter value not reset: got %d, want 0", name, *x)
 						}
 						sawReset = true
 					case *nonResetter:
 						if x.val != 77 {
-							t.Errorf("TestPoolPutReset(%s): nonResetter value changed: got %d, want 77", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged", x.val)
+							t.Errorf("TestPoolPutReset(%s): nonResetter value changed: got %d, want 77", name, x.val)
 						}
 						sawNonResetter = true
 					}
 				}
 				if !sawReset {
-					t.Errorf("TestPoolPutReset(%s): never saw Resetter value", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged")
+					t.Errorf("TestPoolPutReset(%s): never saw Resetter value", name)
 				}
 				if !sawNonResetter {
-					t.Errorf("TestPoolPutReset(%s): never saw nonResetter value", "Success: Pool[any] resets Resetter but leaves non-Resetter unchanged")
+					t.Errorf("TestPoolPutReset(%s): never saw nonResetter value", name)
 				}
 			},
 		},
 	}
 
 	for _, test := range tests {
-		test.fn(t)
+		test.fn(t, test.name)
 	}
 }
 

--- a/concurrency/worker/limited_test.go
+++ b/concurrency/worker/limited_test.go
@@ -8,6 +8,41 @@ import (
 	"time"
 )
 
+func TestRegressionLimitedCancelRelease(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p, err := New(ctx, "")
+	if err != nil {
+		panic(err)
+	}
+
+	const limit = 2
+	l := p.Limited(t.Context(), "", limit)
+
+	// Submit with an already-cancelled context. The token must be released
+	// even though the job never runs, otherwise the pool leaks capacity.
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	for i := 0; i < limit; i++ {
+		l.Submit(cancelled, func() { t.Errorf("TestRegressionLimitedCancelRelease: job should not run on cancelled context") })
+	}
+
+	// If tokens leaked, this submit on a live context will deadlock.
+	done := make(chan struct{})
+	go func() {
+		l.Submit(ctx, func() {})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("TestRegressionLimitedCancelRelease: submit blocked, token was not released on cancelled context")
+	}
+}
+
 func TestLimited(t *testing.T) {
 	t.Parallel()
 

--- a/concurrency/worker/priority.go
+++ b/concurrency/worker/priority.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,6 +41,13 @@ func (p *queue) Less(i, j int) bool {
 }
 
 func (p *queue) Swap(i, j int) {
+	defer func() {
+		if a := recover(); a != nil {
+			log.Printf("i %d, j %d", i, j)
+			panic(a)
+		}
+	}()
+
 	p.jobs[i], p.jobs[j] = p.jobs[j], p.jobs[i]
 }
 
@@ -159,16 +167,10 @@ func (d *Queue) Submit(ctx context.Context, job QJob) error {
 
 	d.mu.Lock()
 	heap.Push(ctx, d.queue, job)
-	var popped QJob
-	var hasPopped bool
 	if len(d.next) == 0 && d.queue.Len() != 0 {
-		popped = heap.Pop(ctx, d.queue)
-		hasPopped = true
+		d.next <- heap.Pop(ctx, d.queue)
 	}
 	d.mu.Unlock()
-	if hasPopped {
-		d.next <- popped
-	}
 
 	return nil
 }
@@ -185,16 +187,10 @@ func (d *Queue) doWork() {
 		case job = <-d.next:
 			<-d.size
 			d.mu.Lock()
-			var popped QJob
-			var hasPopped bool
 			if len(d.next) == 0 && d.queue.Len() != 0 {
-				popped = heap.Pop(ctx, d.queue)
-				hasPopped = true
+				d.next <- heap.Pop(ctx, d.queue)
 			}
 			d.mu.Unlock()
-			if hasPopped {
-				d.next <- popped
-			}
 		}
 
 		d.queueLen.Add(-1)

--- a/concurrency/worker/priority.go
+++ b/concurrency/worker/priority.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"errors"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -41,13 +40,6 @@ func (p *queue) Less(i, j int) bool {
 }
 
 func (p *queue) Swap(i, j int) {
-	defer func() {
-		if a := recover(); a != nil {
-			log.Printf("i %d, j %d", i, j)
-			panic(a)
-		}
-	}()
-
 	p.jobs[i], p.jobs[j] = p.jobs[j], p.jobs[i]
 }
 
@@ -167,10 +159,16 @@ func (d *Queue) Submit(ctx context.Context, job QJob) error {
 
 	d.mu.Lock()
 	heap.Push(ctx, d.queue, job)
+	var popped QJob
+	var hasPopped bool
 	if len(d.next) == 0 && d.queue.Len() != 0 {
-		d.next <- heap.Pop(ctx, d.queue)
+		popped = heap.Pop(ctx, d.queue)
+		hasPopped = true
 	}
 	d.mu.Unlock()
+	if hasPopped {
+		d.next <- popped
+	}
 
 	return nil
 }
@@ -187,10 +185,16 @@ func (d *Queue) doWork() {
 		case job = <-d.next:
 			<-d.size
 			d.mu.Lock()
+			var popped QJob
+			var hasPopped bool
 			if len(d.next) == 0 && d.queue.Len() != 0 {
-				d.next <- heap.Pop(ctx, d.queue)
+				popped = heap.Pop(ctx, d.queue)
+				hasPopped = true
 			}
 			d.mu.Unlock()
+			if hasPopped {
+				d.next <- popped
+			}
 		}
 
 		d.queueLen.Add(-1)

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -372,6 +372,15 @@ func (p *Pool) limitedSubmit(ctx context.Context, f func()) {
 	spanner := span.Get(ctx)
 
 	t := time.Now()
+
+	// Fast path: try non-blocking acquire to avoid timer allocation in the common case.
+	select {
+	case p.limit <- struct{}{}:
+		goto acquired
+	default:
+	}
+
+	// Slow path: slot is contended, need to wait.
 	if p.opts.disableLimitedWarn {
 		select {
 		case <-ctx.Done():
@@ -398,6 +407,8 @@ func (p *Pool) limitedSubmit(ctx context.Context, f func()) {
 			break
 		}
 	}
+
+acquired:
 
 	spanner.Event(
 		"worker.Pool:Limited.Submit()",
@@ -450,6 +461,7 @@ func (p *Pool) submit(ctx context.Context, f func()) {
 		// we will try again to create a new goroutine and submit the job. This is a rare case, but can happen
 		// if the number of CPUs is very low.
 		default:
+			runtime.Gosched()
 			goto tryAgain
 		}
 	}

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -421,17 +421,20 @@ acquired:
 		f()
 		<-p.limit
 	}
-	p.submit(ctx, wrap)
+	if !p.submit(ctx, wrap) {
+		<-p.limit // Release the token since wrap() will never run.
+	}
 }
 
 // submit submits the function to be executed. If the context is canceled before the
 // function is executed, the function will not be executed. Once the function is executed,
 // it is the responsibility of the function to check the context and return if it is canceled.
-func (p *Pool) submit(ctx context.Context, f func()) {
+// Returns true if the job was enqueued, false if ctx was cancelled before enqueue.
+func (p *Pool) submit(ctx context.Context, f func()) bool {
 	spanner := span.Get(ctx)
 
 	if f == nil {
-		return
+		return false
 	}
 
 	now := time.Now()
@@ -443,7 +446,7 @@ func (p *Pool) submit(ctx context.Context, f func()) {
 	// User cancelled before we could submit.
 	case <-ctx.Done():
 		args.done() // This will decrement the waitgroup.
-		return
+		return false
 	// Try to submit the job.
 	case p.queue <- args:
 	// We couldn't submit the job because the queue is full. We will create a new goroutine
@@ -457,7 +460,7 @@ func (p *Pool) submit(ctx context.Context, f func()) {
 		select {
 		case <-ctx.Done():
 			args.done() // This will decrement the waitgroup.
-			return
+			return false
 		case p.queue <- args:
 		// default can happen if the queue fills again with another job before we can submit. In those cases,
 		// we will try again to create a new goroutine and submit the job. This is a rare case, but can happen
@@ -468,6 +471,7 @@ func (p *Pool) submit(ctx context.Context, f func()) {
 		}
 	}
 	p.submitEvent(spanner, now)
+	return true
 }
 
 var numCPU int

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -354,8 +354,9 @@ func (p *Pool) StaticPool() int {
 }
 
 // Submit submits the function to be executed. If the context is canceled before the
-// function is executed, the function will not be executed. Once the function is executed,
-// it is the responsibility of the function to check the context and return if it is canceled.
+// function is enqueued, the function will not be executed. Once enqueued, the function
+// will run regardless of context cancellation; it is the responsibility of the function
+// to check the context and return if it is canceled.
 func (p *Pool) Submit(ctx context.Context, f func()) {
 	if p.limit != nil {
 		p.limitedSubmit(ctx, f)
@@ -427,8 +428,9 @@ acquired:
 }
 
 // submit submits the function to be executed. If the context is canceled before the
-// function is executed, the function will not be executed. Once the function is executed,
-// it is the responsibility of the function to check the context and return if it is canceled.
+// function is enqueued, the function will not be executed. Once enqueued, the function
+// will run regardless of context cancellation; it is the responsibility of the function
+// to check the context and return if it is canceled.
 // Returns true if the job was enqueued, false if ctx was cancelled before enqueue.
 func (p *Pool) submit(ctx context.Context, f func()) bool {
 	spanner := span.Get(ctx)

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -375,6 +375,8 @@ func (p *Pool) limitedSubmit(ctx context.Context, f func()) {
 
 	// Fast path: try non-blocking acquire to avoid timer allocation in the common case.
 	select {
+	case <-ctx.Done():
+		return
 	case p.limit <- struct{}{}:
 		goto acquired
 	default:


### PR DESCRIPTION
This pull request introduces several improvements and optimizations to the concurrency package, focusing on performance, correctness, and code clarity. The most significant changes include optimizing object pooling, improving span recording in groups, refining worker pool logic for better efficiency, and enhancing the worker queue's correctness. Additionally, some unnecessary code and error handling were removed for clarity.

**Object Pooling and Reset Optimization:**
- Added an `isResetter` flag to `Pool[T]` in `pool.go` to determine at construction time whether the pooled type implements the `Resetter` interface, allowing the `Put` method to avoid repeated type assertions and improving performance. [[1]](diffhunk://#diff-0404395c86a92a076e44c84df67591ebcf903d4f6c50d908c9fe2d31faa7a24bR38-R39) [[2]](diffhunk://#diff-0404395c86a92a076e44c84df67591ebcf903d4f6c50d908c9fe2d31faa7a24bR129-R138) [[3]](diffhunk://#diff-0404395c86a92a076e44c84df67591ebcf903d4f6c50d908c9fe2d31faa7a24bL170-R181)

**Span Recording and Group Management:**
- Introduced an `isRecording` flag to `Group` in `group.go` to track if span recording is active, ensuring that context is only updated with a span when necessary and after reset. [[1]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59R127) [[2]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59R146) [[3]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L194-L208)

**Worker Pool and Queue Improvements:**
- Optimized the `limitedSubmit` method in `worker.go` by adding a fast path for non-blocking slot acquisition, reducing unnecessary timer allocations in the common case. [[1]](diffhunk://#diff-b6211ea8e1dd2b56c676cc6dcfb763d4219bacc682d7c6b16214e48addc476adR375-R383) [[2]](diffhunk://#diff-b6211ea8e1dd2b56c676cc6dcfb763d4219bacc682d7c6b16214e48addc476adR411-R412)
- In the `submit` method, added a call to `runtime.Gosched()` before retrying goroutine creation to yield the processor, improving fairness under contention.

**Code Cleanup and Error Handling:**
- Removed unnecessary logging and panic recovery from the `Swap` method in the priority queue, simplifying the code. [[1]](diffhunk://#diff-61597c9097cc1893f17cc4639831c94b2a2cf44ace0c10946c553cd971c03ac6L6) [[2]](diffhunk://#diff-61597c9097cc1893f17cc4639831c94b2a2cf44ace0c10946c553cd971c03ac6L44-L50)