### PR TITLE
Add an option for locked walk of shardedmaps and some worker corner case fixes

### DIFF
--- a/concurrency/background/background.go
+++ b/concurrency/background/background.go
@@ -66,7 +66,7 @@ type RunOption func(runOpts) (runOpts, error)
 // meaning the name has to be unique within that function. The Task is the function to run. If
 // task() ends, it will use the Backoff provided to restart the Task. If Context is canceled, this will stop
 // launching the task, however, the task itself has to honor the context passed to it in order for it to be stopped.
-// An error is only returned if an option fails.
+// An error is returned if an option fails or if ctx is already canceled before the task could be started.
 // Do not try to use this for a cron like task. If you need to run background cron like tasks,
 // use the .Once() method wrapped with some timer.
 func (t *Tasks) Run(ctx context.Context, name string, task Task, boff *exponential.Backoff, options ...RunOption) error {
@@ -110,15 +110,9 @@ func (t *Tasks) Run(ctx context.Context, name string, task Task, boff *exponenti
 	}
 
 	// Restarts the task if it ends.
-	t.pool.Submit(
-		ctx,
-		func() {
-			boff.Retry(
-				ctx,
-				t.taskWrapper(name, bm, task),
-			)
-		},
-	)
+	if !t.pool.Submit(ctx, func() { boff.Retry(ctx, t.taskWrapper(name, bm, task)) }) {
+		return fmt.Errorf("background/Tasks.Run: context canceled before task %q could start: %w", name, context.Cause(ctx))
+	}
 
 	return nil
 }
@@ -168,6 +162,7 @@ func (t *Tasks) taskWrapper(name string, bm *backgroundTaskMetrics, task Task) e
 
 // Once is like Run, but it only runs the function once. If the function ends, it will not
 // be restarted. name can be reused if you want to keep stats on a collection of one shot tasks.
+// An error is returned if an option fails or if ctx is already canceled before the task could be started.
 func (t *Tasks) Once(ctx context.Context, name string, task Task, options ...RunOption) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -195,7 +190,7 @@ func (t *Tasks) Once(ctx context.Context, name string, task Task, options ...Run
 		t.tm.OnceTasks[name] = otm
 	}
 
-	t.pool.Submit(
+	submitted := t.pool.Submit(
 		ctx,
 		func() {
 			otm.ExecutedTotal.Add(ctx, 1)
@@ -216,6 +211,9 @@ func (t *Tasks) Once(ctx context.Context, name string, task Task, options ...Run
 			err = task(ctx)
 		},
 	)
+	if !submitted {
+		return fmt.Errorf("background/Tasks.Once: context canceled before task %q could start: %w", name, context.Cause(ctx))
+	}
 	return nil
 }
 

--- a/concurrency/background/background_test.go
+++ b/concurrency/background/background_test.go
@@ -170,7 +170,7 @@ func TestBackgroundWithBackoff(t *testing.T) {
 }
 
 func TestOnce(t *testing.T) {
-	t.Parallel()
+	// Not parallel: bubble() replaces the global worker.Default() for synctest determinism.
 
 	b := New(context.Background())
 	defer b.Close(context.Background())
@@ -240,7 +240,7 @@ func TestRunOnceCanceledContext(t *testing.T) {
 }
 
 func TestCloseContextExpires(t *testing.T) {
-	t.Parallel()
+	// Not parallel: bubble() replaces the global worker.Default() for synctest determinism.
 
 	tests := []struct {
 		name string

--- a/concurrency/background/background_test.go
+++ b/concurrency/background/background_test.go
@@ -6,10 +6,35 @@ import (
 	"log"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
+
+	"github.com/gostdlib/base/concurrency/worker"
 
 	"github.com/Azure/retry/exponential"
 )
+
+// bubble runs f inside a testing/synctest bubble after installing a fresh worker pool as the
+// default pool. background.New() draws its goroutines from worker.Default(); creating that pool
+// inside the bubble is what lets the bubble's fake clock control the background tasks' timers.
+// The previous default pool is restored when the bubble exits.
+func bubble(t *testing.T, f func(t *testing.T)) {
+	t.Helper()
+
+	original := worker.Default()
+	defer worker.Set(original)
+
+	synctest.Test(t, func(t *testing.T) {
+		bp, err := worker.New(context.Background(), "bubblePool")
+		if err != nil {
+			t.Fatalf("%s: creating bubble pool: %s", t.Name(), err)
+		}
+		worker.Set(bp)
+		defer bp.Close(context.Background())
+
+		f(t)
+	})
+}
 
 var noBackoff *exponential.Backoff
 
@@ -30,128 +55,118 @@ func init() {
 	}
 }
 
-func TestBackgroundBasics(t *testing.T) {
-	t.Parallel()
-
-	b := New(context.Background())
-	defer b.Close(context.Background())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	count := atomic.Uint64{}
-	b.Run(
-		ctx,
-		"TestBackground-func1",
-		func(ctx context.Context) error {
-			for {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				count.Add(1)
-				time.Sleep(100 * time.Millisecond)
-			}
+func TestBackground(t *testing.T) {
+	tests := []struct {
+		name  string
+		crash bool
+	}{
+		{
+			name:  "Success: non-crashing task loops then stops on cancel",
+			crash: false,
 		},
-		noBackoff,
-	)
-
-	time.Sleep(500 * time.Millisecond)
-	if count.Load() < 2 {
-		t.Fatalf("TestBackground: expected function to have looped at least twice")
+		{
+			name:  "Success: crashing task is restarted by backoff then stops on cancel",
+			crash: true,
+		},
 	}
-	cancel()
-	time.Sleep(200 * time.Millisecond)
-	v := count.Load()
-	time.Sleep(200 * time.Millisecond)
-	if v != count.Load() {
-		t.Fatalf("TestBackground: looks like the function didn't exit")
-	}
-}
 
-func TestBackgroundWhenCrashing(t *testing.T) {
-	t.Parallel()
+	for _, test := range tests {
+		bubble(t, func(t *testing.T) {
+			b := New(context.Background())
+			defer b.Close(context.Background())
 
-	b := New(context.Background())
-	defer b.Close(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+			count := atomic.Uint64{}
+			b.Run(
+				ctx,
+				"TestBackground-task",
+				func(ctx context.Context) error {
+					for {
+						if ctx.Err() != nil {
+							return ctx.Err()
+						}
+						count.Add(1)
+						time.Sleep(100 * time.Millisecond)
+						// A crashing task returns an error each iteration; noBackoff then restarts it,
+						// which must keep the count climbing just like the internally-looping task.
+						if test.crash {
+							return errors.New("crap")
+						}
+					}
+				},
+				noBackoff,
+			)
 
-	count := atomic.Uint64{}
-	b.Run(
-		ctx,
-		"TestBackground-func2",
-		func(ctx context.Context) error {
-			if ctx.Err() != nil {
-				return ctx.Err()
+			time.Sleep(500 * time.Millisecond)
+			if count.Load() < 2 {
+				t.Fatalf("TestBackground(%s): expected function to have looped at least twice", test.name)
 			}
-			count.Add(1)
+			cancel()
+			// Advance the fake clock past the task's in-flight Sleep so it observes the cancellation,
+			// then wait for the task goroutine to settle. The count must not change after that.
 			time.Sleep(100 * time.Millisecond)
-			return errors.New("crap")
-		},
-		noBackoff,
-	)
-
-	time.Sleep(500 * time.Millisecond)
-	if count.Load() < 2 {
-		t.Fatalf("TestBackgroundWhenCrashing: expected function to have looped at least twice")
-	}
-	cancel()
-	time.Sleep(200 * time.Millisecond)
-	v := count.Load()
-	time.Sleep(200 * time.Millisecond)
-	if v != count.Load() {
-		t.Fatalf("TestBackgroundWhenCrashing: looks like the function didn't exit")
+			synctest.Wait()
+			v := count.Load()
+			synctest.Wait()
+			if v != count.Load() {
+				t.Fatalf("TestBackground(%s): looks like the function didn't exit", test.name)
+			}
+		})
 	}
 }
 
 func TestBackgroundWithBackoff(t *testing.T) {
-	t.Parallel()
+	bubble(t, func(t *testing.T) {
+		_10Sec, err := exponential.New(
+			exponential.WithPolicy(
+				exponential.Policy{
+					InitialInterval:     10 * time.Second,
+					MaxInterval:         10 * time.Second,
+					Multiplier:          1.1,
+					RandomizationFactor: 0,
+				},
+			),
+		)
+		if err != nil {
+			panic(err)
+		}
 
-	_10Sec, err := exponential.New(
-		exponential.WithPolicy(
-			exponential.Policy{
-				InitialInterval:     10 * time.Second,
-				MaxInterval:         10 * time.Second,
-				Multiplier:          1.1,
-				RandomizationFactor: 0,
+		b := New(context.Background())
+		defer b.Close(context.Background())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		count := atomic.Uint64{}
+		b.Run(
+			ctx,
+			"TestBackground-func3",
+			func(ctx context.Context) error {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				count.Add(1)
+				log.Println("hello")
+				return errors.New("crap")
 			},
-		),
-	)
-	if err != nil {
-		panic(err)
-	}
+			_10Sec,
+		)
 
-	b := New(context.Background())
-	defer b.Close(context.Background())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	count := atomic.Uint64{}
-	b.Run(
-		ctx,
-		"TestBackground-func3",
-		func(ctx context.Context) error {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			count.Add(1)
-			log.Println("hello")
-			return errors.New("crap")
-		},
-		_10Sec,
-	)
-
-	time.Sleep(5 * time.Second)
-	if count.Load() != 1 {
-		t.Fatalf("TestBackgroundWhenCrashing: expected function to have not retried yet(was %d)", count.Load())
-	}
-	time.Sleep(6 * time.Second)
-	cancel()
-	if count.Load() != 2 {
-		t.Fatalf("TestBackgroundWhenCrashing: its ignoring the backoff")
-	}
+		// Each Sleep advances the bubble's fake clock; the 10s backoff is what we are verifying.
+		// No synctest.Wait() is needed: the retry timer (T=10s) fires strictly before the main
+		// goroutine's next wake (T=11s), so the worker has already run and re-settled by then.
+		time.Sleep(5 * time.Second)
+		if count.Load() != 1 {
+			t.Fatalf("TestBackgroundWhenCrashing: expected function to have not retried yet(was %d)", count.Load())
+		}
+		time.Sleep(6 * time.Second)
+		cancel()
+		if count.Load() != 2 {
+			t.Fatalf("TestBackgroundWhenCrashing: its ignoring the backoff")
+		}
+	})
 }
 
 func TestOnce(t *testing.T) {
@@ -174,6 +189,54 @@ func TestOnce(t *testing.T) {
 	)
 
 	<-done
+}
+
+// TestRunOnceCanceledContext verifies that Run and Once report an error (and do not start the
+// task) when the context is already canceled before the task can be submitted, and report nil
+// on a live context. This exercises the bool returned by the underlying pool.Submit.
+func TestRunOnceCanceledContext(t *testing.T) {
+	task := func(ctx context.Context) error {
+		<-ctx.Done()
+		return nil
+	}
+
+	tests := []struct {
+		name    string
+		once    bool
+		cancel  bool
+		wantErr bool
+	}{
+		{name: "Success: Run with a live context starts the task", wantErr: false},
+		{name: "Success: Once with a live context starts the task", once: true, wantErr: false},
+		{name: "Error: Run with a canceled context does not start the task", cancel: true, wantErr: true},
+		{name: "Error: Once with a canceled context does not start the task", once: true, cancel: true, wantErr: true},
+	}
+
+	for _, test := range tests {
+		b := New(context.Background())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		if test.cancel {
+			cancel()
+		}
+
+		var err error
+		if test.once {
+			err = b.Once(ctx, "TestRunOnce-once", task)
+		} else {
+			err = b.Run(ctx, "TestRunOnce-run", task, noBackoff)
+		}
+
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestRunOnceCanceledContext(%s): got err == nil, want err != nil", test.name)
+		case err != nil && !test.wantErr:
+			t.Errorf("TestRunOnceCanceledContext(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		cancel()
+		b.Close(context.Background())
+	}
 }
 
 func TestCloseContextExpires(t *testing.T) {

--- a/concurrency/sync/group.go
+++ b/concurrency/sync/group.go
@@ -17,8 +17,9 @@ import (
 // to submit work to.
 type WorkerPool interface {
 	// Submit submits a function to the pool for execution. The context is for the
-	// pool use, not the function itself.
-	Submit(ctx context.Context, f func())
+	// pool use, not the function itself. If the context is cancelled before the function is executed,
+	// the function will not be executed and false will be returned. Otherwise true will be returned.
+	Submit(ctx context.Context, f func()) bool
 }
 
 // IndexErr is an error that includes the index of the error. This will
@@ -239,7 +240,9 @@ func (w *Group) noBackoff(ctx context.Context, f func(ctx context.Context) error
 		go w.executeFn(ctx, f, opts)
 		return
 	}
-	w.Pool.Submit(ctx, func() { w.executeFn(ctx, f, opts) })
+	if !w.Pool.Submit(ctx, func() { w.executeFn(ctx, f, opts) }) {
+		w.declined(ctx, opts)
+	}
 }
 
 // withBackoff is a helper function that executes the function f and handles the
@@ -258,7 +261,7 @@ func (w *Group) withBackoff(ctx context.Context, f func(ctx context.Context) err
 		return
 	}
 
-	w.Pool.Submit(
+	submitted := w.Pool.Submit(
 		ctx,
 		func() {
 			opts.backoff.Retry(
@@ -269,6 +272,22 @@ func (w *Group) withBackoff(ctx context.Context, f func(ctx context.Context) err
 			)
 		},
 	)
+	if !submitted {
+		w.declined(ctx, opts)
+	}
+}
+
+// declined unwinds the accounting done by execute() when the Pool refuses to run a job (Submit
+// returned false, e.g. the context was cancelled before the job could be enqueued). It mirrors
+// executeFn's cancelled-context path so Wait() returns and reports the cause rather than hanging
+// on a wg.Add(1) that would otherwise never be matched by a wg.Done().
+func (w *Group) declined(ctx context.Context, opts goOpts) {
+	defer w.count.Add(-1)
+	defer w.wg.Done()
+
+	if err := context.Cause(ctx); err != nil {
+		w.recErr(opts.index, err)
+	}
 }
 
 // executeFn is a helper function that executes the function f and handles the

--- a/concurrency/sync/group_declined_test.go
+++ b/concurrency/sync/group_declined_test.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeDecliningPool mirrors worker.Pool's documented Submit contract: a job submitted with an
+// already-cancelled context is declined (not run) and Submit returns false; otherwise it runs
+// the job and returns true.
+type fakeDecliningPool struct{}
+
+func (fakeDecliningPool) Submit(ctx context.Context, f func()) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	go f()
+	return true
+}
+
+// TestGroupDeclinedSubmit guards against a regression where a Group backed by a pool deadlocked
+// in Wait(): execute() calls wg.Add(1), but when Submit declines the job (cancelled context) the
+// matching wg.Done() never happens because the job never runs. The fix unwinds the accounting and
+// records the cause when Submit returns false.
+func TestGroupDeclinedSubmit(t *testing.T) {
+	tests := []struct {
+		name      string
+		cancelCtx bool
+		wantRan   int32
+		wantErr   bool
+	}{
+		{
+			name:    "Success: live context runs the job and Wait returns nil",
+			wantRan: 1,
+			wantErr: false,
+		},
+		{
+			name:      "Error: cancelled context declines the job; Wait returns the cause and does not hang",
+			cancelCtx: true,
+			wantRan:   0,
+			wantErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		grp := Group{Pool: fakeDecliningPool{}}
+
+		jobCtx := context.Background()
+		if test.cancelCtx {
+			c, cancel := context.WithCancel(context.Background())
+			cancel()
+			jobCtx = c
+		}
+
+		var ran atomic.Int32
+		grp.Go(jobCtx, func(ctx context.Context) error {
+			ran.Add(1)
+			return nil
+		})
+
+		// Wait() must not be cancellable, so it gets its own live context. Run it off the test
+		// goroutine so a regression (the old deadlock) is reported as a failure instead of hanging
+		// the whole test binary.
+		waitErr := make(chan error, 1)
+		go func() {
+			waitErr <- grp.Wait(context.Background())
+		}()
+
+		var err error
+		select {
+		case err = <-waitErr:
+		case <-time.After(5 * time.Second):
+			t.Errorf("TestGroupDeclinedSubmit(%s): Group.Wait() deadlocked (Submit-declined job left wg.Add unmatched)", test.name)
+			continue
+		}
+
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestGroupDeclinedSubmit(%s): got err == nil, want err != nil", test.name)
+		case err != nil && !test.wantErr:
+			t.Errorf("TestGroupDeclinedSubmit(%s): got err == %s, want err == nil", test.name, err)
+		}
+
+		if got := ran.Load(); got != test.wantRan {
+			t.Errorf("TestGroupDeclinedSubmit(%s): job ran %d times, want %d", test.name, got, test.wantRan)
+		}
+	}
+}

--- a/concurrency/sync/internal/shardmap/map.go
+++ b/concurrency/sync/internal/shardmap/map.go
@@ -149,6 +149,34 @@ func (m *Map[K, V]) All() iter.Seq2[K, V] {
 	}
 }
 
+// AllLocked returns a sequence of all key/values. It read-locks each shard while yielding that shard's
+// entries and releases the lock before moving to the next shard, so other goroutines may safely read and
+// write the map during iteration (a write to the shard being yielded blocks until that shard completes).
+// It is not a whole-map snapshot. Do not call Get, Set, or Delete from inside the iteration loop itself:
+// re-entering the shard being yielded can deadlock.
+func (m *Map[K, V]) AllLocked() iter.Seq2[K, V] {
+	m.initDo()
+	return func(yield func(K, V) bool) {
+		for i := 0; i < m.shards; i++ {
+			// Run each shard's yield loop in a closure so the RUnlock happens via defer, releasing the
+			// shard lock even if the caller breaks (yield returns false) or yield panics.
+			stop := func() bool {
+				m.mus[i].RLock()
+				defer m.mus[i].RUnlock()
+				for k, v := range m.maps[i].All() {
+					if !yield(k, v) {
+						return true
+					}
+				}
+				return false
+			}()
+			if stop {
+				return
+			}
+		}
+	}
+}
+
 func (m *Map[K, V]) choose(key K) int {
 	return int(maphash.Comparable(m.seed, key) & uint64(m.shards-1))
 }

--- a/concurrency/sync/shardedmaps.go
+++ b/concurrency/sync/shardedmaps.go
@@ -66,8 +66,37 @@ func (s *ShardedMap[K, V]) CompareAndDelete(k K, old V) (deleted bool) {
 	return s.sm.CompareAndDelete(k, old)
 }
 
-// All returns an iterator for the map for use with range.
-// Not thread safe, only use when no other write calls are being made.
-func (s *ShardedMap[K, V]) All() iter.Seq2[K, V] {
+type allOptions struct {
+	lock bool
+}
+
+type AllOption func(o allOptions) allOptions
+
+// WithLock makes All() read-lock each shard while yielding that shard's entries, so other goroutines may
+// safely read and write the map while you iterate. Locking is per-shard and released as each shard
+// completes, so iteration is not a whole-map snapshot: writes to shards other than the one being yielded
+// happen concurrently and may or may not be observed. Do not call Get(), Set(), or Del() from inside the
+// iteration loop.
+func WithLock() AllOption {
+	return func(o allOptions) allOptions {
+		o.lock = true
+		return o
+	}
+}
+
+// All returns an iterator for the map for use with range. Without options it is not thread safe: only use
+// it when no other reads or writes are happening. Pass WithLock() to make iteration safe alongside
+// concurrent readers and writers; see WithLock for the per-shard semantics and restrictions.
+func (s *ShardedMap[K, V]) All(options ...AllOption) iter.Seq2[K, V] {
+	if len(options) == 0 {
+		return s.sm.All()
+	}
+	var opts allOptions
+	for _, option := range options {
+		opts = option(opts)
+	}
+	if opts.lock {
+		return s.sm.AllLocked()
+	}
 	return s.sm.All()
 }

--- a/concurrency/sync/shardedmaps_test.go
+++ b/concurrency/sync/shardedmaps_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestShardedMap(t *testing.T) {
@@ -54,4 +55,84 @@ func TestShardedMapConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestShardedMapAllLocked(t *testing.T) {
+	m := ShardedMap[string, int]{}
+	const n = 1000
+	for i := 0; i < n; i++ {
+		m.Set(fmt.Sprintf("key%d", i), i)
+	}
+
+	// Other goroutines reading concurrently must be safe while we iterate under WithLock(); run under
+	// -race to catch any unsynchronized access.
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			m.Get(fmt.Sprintf("key%d", i))
+		}(i)
+	}
+
+	seen := 0
+	for range m.All(WithLock()) {
+		seen++
+	}
+	wg.Wait()
+
+	if seen != n {
+		t.Errorf("TestShardedMapAllLocked: iterated %d entries, want %d", seen, n)
+	}
+}
+
+func TestShardedMapAllLockedReleasesLock(t *testing.T) {
+	tests := []struct {
+		name string
+		// stop ends a WithLock() iteration early in a particular way; afterwards the shard lock must
+		// have been released or subsequent writes would deadlock.
+		stop func(m *ShardedMap[string, int])
+	}{
+		{
+			name: "Success: breaking out of the iteration releases the shard lock",
+			stop: func(m *ShardedMap[string, int]) {
+				for range m.All(WithLock()) {
+					break
+				}
+			},
+		},
+		{
+			name: "Success: a panic in the iteration releases the shard lock",
+			stop: func(m *ShardedMap[string, int]) {
+				defer func() { _ = recover() }()
+				for range m.All(WithLock()) {
+					panic("boom")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		m := ShardedMap[string, int]{}
+		for i := 0; i < 100; i++ {
+			m.Set(fmt.Sprintf("key%d", i), i)
+		}
+
+		test.stop(&m)
+
+		// If a shard lock leaked, re-writing every key (which touches the leaked shard) would deadlock.
+		done := make(chan struct{})
+		go func() {
+			for i := 0; i < 100; i++ {
+				m.Set(fmt.Sprintf("key%d", i), i*2)
+			}
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("TestShardedMapAllLockedReleasesLock(%s): writes deadlocked; the iteration leaked a shard lock", test.name)
+		}
+	}
 }

--- a/concurrency/sync/singleflight_test.go
+++ b/concurrency/sync/singleflight_test.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 )
 
 type errValue struct{}
@@ -105,49 +105,46 @@ func TestDoErr(t *testing.T) {
 }
 
 func TestDoDupSuppress(t *testing.T) {
-	var g Flight[string, string]
-	var wg1, wg2 sync.WaitGroup
-	c := make(chan string, 1)
-	var calls int32
-	fn := func() (string, error) {
-		if atomic.AddInt32(&calls, 1) == 1 {
-			// First invocation.
-			wg1.Done()
+	synctest.Test(t, func(t *testing.T) {
+		var g Flight[string, string]
+		c := make(chan string, 1)
+		var calls atomic.Int32
+		fn := func() (string, error) {
+			calls.Add(1)
+			v := <-c
+			c <- v // pump; make available for any future calls
+			return v, nil
 		}
-		v := <-c
-		c <- v // pump; make available for any future calls
 
-		time.Sleep(10 * time.Millisecond) // let more goroutines enter Do
+		const n = 10
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				v, err, _ := g.Do(t.Context(), "key", fn)
+				if err != nil {
+					t.Errorf("Do error: %v", err)
+					return
+				}
+				if v != "bar" {
+					t.Errorf("Do = %T %v; want %q", v, v, "bar")
+				}
+			}()
+		}
 
-		return v, nil
-	}
+		// Wait until all n goroutines are durably blocked: exactly one is inside fn waiting on
+		// c, and the rest are waiting on that in-flight call. This replaces the original 10ms
+		// sleep that was used to "let more goroutines enter Do", and lets us assert the exact
+		// number of calls rather than a fuzzy range.
+		synctest.Wait()
+		c <- "bar"
+		wg.Wait()
 
-	const n = 10
-	wg1.Add(1)
-	for i := 0; i < n; i++ {
-		wg1.Add(1)
-		wg2.Add(1)
-		go func() {
-			defer wg2.Done()
-			wg1.Done()
-			v, err, _ := g.Do(t.Context(), "key", fn)
-			if err != nil {
-				t.Errorf("Do error: %v", err)
-				return
-			}
-			if v != "bar" {
-				t.Errorf("Do = %T %v; want %q", v, v, "bar")
-			}
-		}()
-	}
-	wg1.Wait()
-	// At least one goroutine is in fn now and all of them have at
-	// least reached the line before the Do.
-	c <- "bar"
-	wg2.Wait()
-	if got := atomic.LoadInt32(&calls); got <= 0 || got >= n {
-		t.Errorf("number of calls = %d; want over 0 and less than %d", got, n)
-	}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("number of calls = %d; want exactly 1", got)
+		}
+	})
 }
 
 // Test that singleflight behaves correctly after Forget called.
@@ -213,72 +210,70 @@ func TestDoChan(t *testing.T) {
 // Test singleflight behaves correctly after Do panic.
 // See https://github.com/golang/go/issues/41133
 func TestPanicDo(t *testing.T) {
-	var g Flight[string, struct{}]
-	fn := func() (struct{}, error) {
-		panic("invalid memory address or nil pointer dereference")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		var g Flight[string, struct{}]
+		fn := func() (struct{}, error) {
+			panic("invalid memory address or nil pointer dereference")
+		}
 
-	const n = 5
-	waited := int32(n)
-	panicCount := int32(0)
-	done := make(chan struct{})
-	for i := 0; i < n; i++ {
-		go func() {
-			defer func() {
-				if err := recover(); err != nil {
-					t.Logf("Got panic: %v\n%s", err, debug.Stack())
-					atomic.AddInt32(&panicCount, 1)
-				}
+		const n = 5
+		waited := int32(n)
+		panicCount := int32(0)
+		done := make(chan struct{})
+		for i := 0; i < n; i++ {
+			go func() {
+				defer func() {
+					if err := recover(); err != nil {
+						t.Logf("Got panic: %v\n%s", err, debug.Stack())
+						atomic.AddInt32(&panicCount, 1)
+					}
 
-				if atomic.AddInt32(&waited, -1) == 0 {
-					close(done)
-				}
+					if atomic.AddInt32(&waited, -1) == 0 {
+						close(done)
+					}
+				}()
+
+				g.Do(t.Context(), "key", fn)
 			}()
+		}
 
-			g.Do(t.Context(), "key", fn)
-		}()
-	}
-
-	select {
-	case <-done:
+		// No timeout guard is needed: if Do hangs, the bubble's deadlock detector fails the test.
+		<-done
 		if panicCount != n {
 			t.Errorf("Expect %d panic, but got %d", n, panicCount)
 		}
-	case <-time.After(time.Second):
-		t.Fatalf("Do hangs")
-	}
+	})
 }
 
 func TestGoexitDo(t *testing.T) {
-	var g Flight[string, struct{}]
-	fn := func() (struct{}, error) {
-		runtime.Goexit()
-		return struct{}{}, nil
-	}
+	synctest.Test(t, func(t *testing.T) {
+		var g Flight[string, struct{}]
+		fn := func() (struct{}, error) {
+			runtime.Goexit()
+			return struct{}{}, nil
+		}
 
-	const n = 5
-	waited := int32(n)
-	done := make(chan struct{})
-	for i := 0; i < n; i++ {
-		go func() {
-			var err error
-			defer func() {
-				if err != nil {
-					t.Errorf("Error should be nil, but got: %v", err)
-				}
-				if atomic.AddInt32(&waited, -1) == 0 {
-					close(done)
-				}
+		const n = 5
+		waited := int32(n)
+		done := make(chan struct{})
+		for i := 0; i < n; i++ {
+			go func() {
+				var err error
+				defer func() {
+					if err != nil {
+						t.Errorf("Error should be nil, but got: %v", err)
+					}
+					if atomic.AddInt32(&waited, -1) == 0 {
+						close(done)
+					}
+				}()
+				_, err, _ = g.Do(t.Context(), "key", fn)
 			}()
-			_, err, _ = g.Do(t.Context(), "key", fn)
-		}()
-	}
+		}
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatalf("Do hangs")
-	}
+		// No timeout guard is needed: if Do hangs, the bubble's deadlock detector fails the test.
+		<-done
+	})
 }
 
 func executable(t testing.TB) string {

--- a/concurrency/worker/limited_test.go
+++ b/concurrency/worker/limited_test.go
@@ -5,120 +5,118 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 )
 
 func TestRegressionLimitedCancelRelease(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		p, err := New(ctx, "")
+		if err != nil {
+			panic(err)
+		}
+		defer p.Close(ctx)
 
-	ctx := context.Background()
-	p, err := New(ctx, "")
-	if err != nil {
-		panic(err)
-	}
+		const limit = 2
+		l := p.Limited(ctx, "", limit)
 
-	const limit = 2
-	l := p.Limited(t.Context(), "", limit)
+		// Submit with an already-cancelled context. The token must be released
+		// even though the job never runs, otherwise the pool leaks capacity.
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
 
-	// Submit with an already-cancelled context. The token must be released
-	// even though the job never runs, otherwise the pool leaks capacity.
-	cancelled, cancel := context.WithCancel(ctx)
-	cancel()
+		for i := 0; i < limit; i++ {
+			if l.Submit(cancelled, func() { t.Errorf("TestRegressionLimitedCancelRelease: job should not run on cancelled context") }) {
+				t.Errorf("TestRegressionLimitedCancelRelease: Submit on a cancelled context returned true, want false")
+			}
+		}
 
-	for i := 0; i < limit; i++ {
-		l.Submit(cancelled, func() { t.Errorf("TestRegressionLimitedCancelRelease: job should not run on cancelled context") })
-	}
+		// If tokens leaked, this submit on a live context would block forever and the bubble's
+		// deadlock detector would fail the test.
+		done := make(chan struct{})
+		go func() {
+			if !l.Submit(ctx, func() {}) {
+				t.Errorf("TestRegressionLimitedCancelRelease: Submit on a live context returned false, want true")
+			}
+			close(done)
+		}()
 
-	// If tokens leaked, this submit on a live context will deadlock.
-	done := make(chan struct{})
-	go func() {
-		l.Submit(ctx, func() {})
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(3 * time.Second):
-		t.Fatalf("TestRegressionLimitedCancelRelease: submit blocked, token was not released on cancelled context")
-	}
+		<-done
+	})
 }
 
 func TestLimited(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		exit := make(chan struct{}, 1)
+		var done atomic.Int32
+		startedWG := sync.WaitGroup{}
+		startedWG.Add(4)
+		f := func() {
+			startedWG.Done()
+			<-exit
+			done.Add(1)
+		}
 
-	exit := make(chan struct{}, 1)
-	var done atomic.Int32
-	startedWG := sync.WaitGroup{}
-	startedWG.Add(4)
-	f := func() {
-		startedWG.Done()
-		<-exit
-		done.Add(1)
-	}
+		ctx := context.Background()
+		p, err := New(ctx, "")
+		if err != nil {
+			panic(err)
+		}
+		defer p.Close(ctx)
 
-	ctx := context.Background()
-	p, err := New(ctx, "")
-	if err != nil {
-		panic(err)
-	}
+		l := p.Limited(ctx, "", 4)
+		for i := 0; i < 4; i++ {
+			if !l.Submit(ctx, f) {
+				t.Fatalf("TestLimited: Submit on a live context returned false, want true")
+			}
+		}
 
-	l := p.Limited(t.Context(), "", 4)
-	l.Submit(ctx, f)
-	l.Submit(ctx, f)
-	l.Submit(ctx, f)
-	l.Submit(ctx, f)
+		// Wait for each of these to start running.
+		startedWG.Wait()
 
-	// Wait for each of these to start running.
-	startedWG.Wait()
+		blockedHappened := make(chan struct{})
+		go func() {
+			// This submit blocks until a slot frees, then runs, so it must report true.
+			if !l.Submit(ctx, func() { defer close(blockedHappened) }) {
+				t.Errorf("TestLimited: blocked Submit on a live context returned false, want true")
+			}
+		}()
 
-	blockedHappened := make(chan struct{})
-	go func() {
-		l.Submit(
-			ctx,
-			func() {
-				defer close(blockedHappened)
-			},
-		)
-	}()
+		// Make sure this is working like we think.
+		if done.Load() != 0 {
+			t.Fatalf("TestLimited: a function ended early")
+		}
 
-	// Make sure this is working like we think.
-	if done.Load() != 0 {
-		t.Fatalf("TestLimited: a function ended early")
-	}
+		// The 5th job cannot run: all 4 limited slots are occupied. Once the bubble settles, the
+		// 5th submit is durably blocked acquiring a slot, so its function has not run.
+		synctest.Wait()
+		select {
+		case <-blockedHappened:
+			t.Fatalf("TestLimited: a function that should have been blocked wasn't")
+		default:
+		}
 
-	// Give the blockHappened function time to attempt to run (it shouldn't due to limited jobs).
-	time.Sleep(100 * time.Millisecond)
+		// Free exactly one slot: one original job finishes, which lets the 5th job run.
+		exit <- struct{}{}
 
-	// Test to make sure that didn't happen.
-	select {
-	case <-blockedHappened:
-		t.Fatalf("TestLimited: a function that should have been blocked wasn't")
-	default:
-	}
+		synctest.Wait()
+		select {
+		case <-blockedHappened:
+		default:
+			t.Fatalf("TestLimited: a blocked function should have completed")
+		}
 
-	// Cause all the 1 of the waiting goroutines to run, freeing up blockHappened to be closed.
-	exit <- struct{}{}
+		// One of our original goroutines should be done.
+		if done.Load() != 1 {
+			t.Fatalf("TestLimited: goroutine should have finished")
+		}
 
-	// Wait for blockHappened to close.
-	time.Sleep(100 * time.Millisecond)
-	select {
-	case <-blockedHappened:
-	default:
-		t.Fatalf("TestLimited: a blocked function should have completed")
-	}
+		// Force the others to finish.
+		close(exit)
 
-	// One of our original goroutines should be done.
-	if done.Load() != 1 {
-		t.Fatalf("TestLimited: goroutine should have finished")
-	}
-
-	// Force the others to finish.
-	close(exit)
-
-	// Give time for each to finish.
-	time.Sleep(100 * time.Millisecond)
-
-	if done.Load() != 4 {
-		t.Fatalf("TestLimited: all goroutines should have finished")
-	}
+		synctest.Wait()
+		if done.Load() != 4 {
+			t.Fatalf("TestLimited: all goroutines should have finished")
+		}
+	})
 }

--- a/concurrency/worker/looper.go
+++ b/concurrency/worker/looper.go
@@ -57,7 +57,7 @@ func Seq[K comparable, V any](ctx context.Context, pool *Pool, seq iter.Seq2[K, 
 			break
 		}
 		wg.Add(1)
-		pool.Submit(
+		submitted := pool.Submit(
 			ctx,
 			func() {
 				defer wg.Done()
@@ -66,6 +66,9 @@ func Seq[K comparable, V any](ctx context.Context, pool *Pool, seq iter.Seq2[K, 
 				}
 			},
 		)
+		if !submitted {
+			wg.Done() // Submit declined the job (ctx canceled); undo the Add so wg.Wait() can complete.
+		}
 	}
 	if cancel != nil {
 		pool.Submit(

--- a/concurrency/worker/priority.go
+++ b/concurrency/worker/priority.go
@@ -127,13 +127,17 @@ func (d *Queue) QueueLen() int {
 func (d *Queue) Wait(ctx context.Context) error {
 	done := make(chan struct{})
 
-	Default().Submit(
+	submitted := Default().Submit(
 		ctx,
 		func() {
 			d.processWait.Wait()
 			close(done)
 		},
 	)
+	if !submitted {
+		// ctx was canceled before the wait could be enqueued; done will never close.
+		return context.Cause(ctx)
+	}
 
 	select {
 	case <-ctx.Done():

--- a/concurrency/worker/submit_cancel_test.go
+++ b/concurrency/worker/submit_cancel_test.go
@@ -1,0 +1,85 @@
+package worker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// TestSubmitContextCancellation guards the documented Submit contract: "If the context is
+// canceled before the function is enqueued, the function will not be executed." Both the
+// regular submit path and the limitedSubmit path previously violated this because their
+// select statements raced <-ctx.Done() against the enqueue/acquire case, so a cancelled-context
+// job ran a fraction of the time. We submit many jobs to make the regression deterministic:
+// buggy code runs a non-zero number of cancelled jobs across the iterations, while the correct
+// behavior runs exactly zero. Live-context cases confirm jobs still run normally.
+func TestSubmitContextCancellation(t *testing.T) {
+	const iters = 2000
+
+	tests := []struct {
+		name      string
+		limited   bool
+		cancelCtx bool
+		wantRuns  int64
+	}{
+		{
+			name:     "Success: live context runs the job on a regular pool",
+			wantRuns: iters,
+		},
+		{
+			name:     "Success: live context runs the job on a limited pool",
+			limited:  true,
+			wantRuns: iters,
+		},
+		{
+			name:      "Error: cancelled context never runs the job on a regular pool",
+			cancelCtx: true,
+			wantRuns:  0,
+		},
+		{
+			name:      "Error: cancelled context never runs the job on a limited pool",
+			limited:   true,
+			cancelCtx: true,
+			wantRuns:  0,
+		},
+	}
+
+	for _, test := range tests {
+		ctx := t.Context()
+
+		p, err := New(ctx, "")
+		if err != nil {
+			t.Fatalf("TestSubmitContextCancellation(%s): New: %s", test.name, err)
+		}
+
+		submitter := p
+		if test.limited {
+			submitter = p.Limited(ctx, "", 4)
+		}
+
+		var runs atomic.Int64
+		var accepted int64
+		for i := 0; i < iters; i++ {
+			jobCtx := ctx
+			if test.cancelCtx {
+				c, cancel := context.WithCancel(ctx)
+				cancel()
+				jobCtx = c
+			}
+			if submitter.Submit(jobCtx, func() { runs.Add(1) }) {
+				accepted++
+			}
+		}
+		submitter.Wait()
+		p.Close(ctx)
+
+		if got := runs.Load(); got != test.wantRuns {
+			t.Errorf("TestSubmitContextCancellation(%s): jobs run = %d, want %d", test.name, got, test.wantRuns)
+		}
+		// Submit's bool return must reflect whether the job was accepted to run: every accepted
+		// (true) submit runs, and every declined (false) submit does not.
+		if accepted != test.wantRuns {
+			t.Errorf("TestSubmitContextCancellation(%s): Submit returned true %d times, want %d", test.name, accepted, test.wantRuns)
+		}
+	}
+}

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -356,28 +356,34 @@ func (p *Pool) StaticPool() int {
 // Submit submits the function to be executed. If the context is canceled before the
 // function is enqueued, the function will not be executed. Once enqueued, the function
 // will run regardless of context cancellation; it is the responsibility of the function
-// to check the context and return if it is canceled.
-func (p *Pool) Submit(ctx context.Context, f func()) {
+// to check the context and return if it is canceled. Submit returns true if the function was
+// accepted to run and false if it was declined (the context was canceled before enqueue).
+func (p *Pool) Submit(ctx context.Context, f func()) bool {
 	if p.limit != nil {
-		p.limitedSubmit(ctx, f)
-		return
+		return p.limitedSubmit(ctx, f)
 	}
-	p.submit(ctx, f)
+	return p.submit(ctx, f)
 }
 
 var warnTimer = 30 * time.Second
 
 // Submit submits function f to be run. Context can be cancelled before submit, however if the function is
 // already submitted it is the responsibility of the function to honor/not honor cancellation.
-func (p *Pool) limitedSubmit(ctx context.Context, f func()) {
+func (p *Pool) limitedSubmit(ctx context.Context, f func()) bool {
 	spanner := span.Get(ctx)
 
 	t := time.Now()
 
+	// Fast-fail an already-cancelled context so we don't needlessly acquire/release a limit
+	// token (the actual no-run guarantee is enforced by submit()).
+	if ctx.Err() != nil {
+		return false
+	}
+
 	// Fast path: try non-blocking acquire to avoid timer allocation in the common case.
 	select {
 	case <-ctx.Done():
-		return
+		return false
 	case p.limit <- struct{}{}:
 		goto acquired
 	default:
@@ -387,7 +393,7 @@ func (p *Pool) limitedSubmit(ctx context.Context, f func()) {
 	if p.opts.disableLimitedWarn {
 		select {
 		case <-ctx.Done():
-			return
+			return false
 		case p.limit <- struct{}{}:
 		}
 	} else {
@@ -396,7 +402,7 @@ func (p *Pool) limitedSubmit(ctx context.Context, f func()) {
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				return
+				return false
 			case <-timer.C:
 				name := p.name
 				if name == "" {
@@ -424,7 +430,9 @@ acquired:
 	}
 	if !p.submit(ctx, wrap) {
 		<-p.limit // Release the token since wrap() will never run.
+		return false
 	}
+	return true
 }
 
 // submit submits the function to be executed. If the context is canceled before the
@@ -436,6 +444,13 @@ func (p *Pool) submit(ctx context.Context, f func()) bool {
 	spanner := span.Get(ctx)
 
 	if f == nil {
+		return false
+	}
+
+	// Honor Submit's documented contract: a context already cancelled before enqueue means the
+	// job must not run. Without this, the select below races <-ctx.Done() against p.queue<-args
+	// and enqueues (runs) the job a fraction of the time.
+	if ctx.Err() != nil {
 		return false
 	}
 

--- a/concurrency/worker/worker_test.go
+++ b/concurrency/worker/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gostdlib/base/telemetry/log"
@@ -16,83 +17,24 @@ import (
 func TestPool(t *testing.T) {
 	t.Parallel()
 
-	namedPool, err := New(t.Context(), "myPool")
-	if err != nil {
-		panic(err)
-	}
-	runPool(namedPool, t)
-
-	anonPool, err := New(t.Context(), "")
-	if err != nil {
-		panic(err)
-	}
-	runPool(anonPool, t)
+	// Exercise both a named (metrics-enabled) and an anonymous pool. The pool must be created
+	// inside runPool's synctest bubble, so we pass the name rather than a pre-built pool.
+	runPool(t, "myPool")
+	runPool(t, "")
 }
 
-func runPool(p *Pool, t *testing.T) {
-	ctx := context.Background()
-	p, err := New(ctx, "myPool")
-	if err != nil {
-		panic(err)
-	}
-
-	verifyPoolGrowth := make(chan bool, 1)
-	go func() {
-		for {
-			if p.goRoutines.Load() > int64(runtime.NumCPU()) {
-				verifyPoolGrowth <- true
-				return
-			}
+func runPool(t *testing.T, name string) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		p, err := New(ctx, name)
+		if err != nil {
+			panic(err)
 		}
-	}()
+		defer p.Close(ctx)
 
-	answer := make([]bool, 1000)
-	for i := 0; i < 1000; i++ {
-		i := i
-		p.Submit(
-			ctx,
-			func() {
-				answer[i] = true
-				time.Sleep(100 * time.Millisecond)
-			},
-		)
-	}
-	p.Wait()
-
-	for i, e := range answer {
-		if !e {
-			t.Fatalf("TestPool: entry(%d) was not set to true as expected", i)
-		}
-	}
-
-	// An extra goroutine that isn't used for 1 second is collected by the pool. By waiting two seconds,
-	// we should see that the number of goroutines is equal to the number of CPUs.
-	time.Sleep(2 * time.Second)
-	if p.GoRoutines() != runtime.NumCPU() {
-		t.Fatalf("TestPool(number of goroutines): got %d, want %d", p.GoRoutines(), runtime.NumCPU())
-	}
-	select {
-	case <-verifyPoolGrowth:
-	default:
-		t.Fatalf("TestPool: pool did not grow as expected")
-	}
-}
-
-func TestSubPool(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	p, err := New(ctx, "myPool")
-	if err != nil {
-		panic(err)
-	}
-
-	sub1 := p.Sub(ctx, "subPool1")
-	sub2 := sub1.Sub(ctx, "subPool2")
-
-	answer := make([]bool, 1000)
-	for i := 0; i < 1000; i++ {
-		if i%3 == 0 {
+		answer := make([]bool, 1000)
+		for i := 0; i < 1000; i++ {
+			i := i
 			p.Submit(
 				ctx,
 				func() {
@@ -100,72 +42,122 @@ func TestSubPool(t *testing.T) {
 					time.Sleep(100 * time.Millisecond)
 				},
 			)
-		} else if i%3 == 1 {
-			sub1.Submit(
-				ctx,
-				func() {
-					answer[i] = true
-					time.Sleep(100 * time.Millisecond)
-				},
-			)
-		} else {
-			sub2.Submit(
-				ctx,
-				func() {
-					answer[i] = true
-					time.Sleep(100 * time.Millisecond)
-				},
-			)
 		}
-	}
 
-	p.Wait()
-	sub1.Wait()
-	sub2.Wait()
-
-	time.Sleep(2 * time.Second) // Wait for extra goroutines to timeout.
-
-	for i, e := range answer {
-		if !e {
-			t.Fatalf("TestSubPool: entry(%d) was not set to true as expected", i)
+		// During the submit burst the fake clock is frozen (the main goroutine never blocks), so
+		// every runner is stuck in its job's Sleep and each excess submit must spawn a new
+		// goroutine. The pool must therefore have grown beyond NumCPU. This replaces the original
+		// busy-loop poller, which never durably blocks and is incompatible with synctest.
+		if got := p.GoRoutines(); got <= runtime.NumCPU() {
+			t.Fatalf("TestPool: pool did not grow as expected: GoRoutines()=%d, NumCPU=%d", got, runtime.NumCPU())
 		}
-	}
 
-	if p.GoRoutines() != sub1.GoRoutines() {
-		t.Fatalf("TestSubPool: pool and sub1 did not have the same number of goroutines")
-	}
+		p.Wait()
 
-	if p.GoRoutines() != sub2.GoRoutines() {
-		t.Fatalf("TestSubPool: pool and sub2 did not have the same number of goroutines")
-	}
+		for i, e := range answer {
+			if !e {
+				t.Fatalf("TestPool: entry(%d) was not set to true as expected", i)
+			}
+		}
 
-	if p.StaticPool() != sub1.StaticPool() {
-		t.Fatal("TestSubPool: pool and sub1 did not have the same number of static pool goroutines")
-	}
-	if p.StaticPool() != sub2.StaticPool() {
-		t.Fatal("TestSubPool: pool and sub2 did not have the same number of static pool goroutines")
-	}
+		// A goroutine beyond the static pool that is idle for the 1s runner timeout is collected.
+		// Advancing the fake clock by two seconds collects them all, leaving exactly NumCPU.
+		time.Sleep(2 * time.Second)
+		if p.GoRoutines() != runtime.NumCPU() {
+			t.Fatalf("TestPool(number of goroutines): got %d, want %d", p.GoRoutines(), runtime.NumCPU())
+		}
+	})
+}
 
-	sub2.Close(ctx)
+func TestSubPool(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		p, err := New(ctx, "myPool")
+		if err != nil {
+			panic(err)
+		}
+		defer p.Close(ctx)
 
-	at := atomic.Int64{}
-	sub1.Submit(
-		ctx,
-		func() {
-			at.Add(1)
-		},
-	)
-	p.Submit(
-		ctx,
-		func() {
-			at.Add(1)
-		},
-	)
-	sub1.Wait()
-	p.Wait()
-	if at.Load() != 2 {
-		t.Fatal("TestSubPool: closing sub2 did something bad")
-	}
+		sub1 := p.Sub(ctx, "subPool1")
+		sub2 := sub1.Sub(ctx, "subPool2")
+
+		answer := make([]bool, 1000)
+		for i := 0; i < 1000; i++ {
+			if i%3 == 0 {
+				p.Submit(
+					ctx,
+					func() {
+						answer[i] = true
+						time.Sleep(100 * time.Millisecond)
+					},
+				)
+			} else if i%3 == 1 {
+				sub1.Submit(
+					ctx,
+					func() {
+						answer[i] = true
+						time.Sleep(100 * time.Millisecond)
+					},
+				)
+			} else {
+				sub2.Submit(
+					ctx,
+					func() {
+						answer[i] = true
+						time.Sleep(100 * time.Millisecond)
+					},
+				)
+			}
+		}
+
+		p.Wait()
+		sub1.Wait()
+		sub2.Wait()
+
+		time.Sleep(2 * time.Second) // Wait for extra goroutines to timeout (fake clock).
+
+		for i, e := range answer {
+			if !e {
+				t.Fatalf("TestSubPool: entry(%d) was not set to true as expected", i)
+			}
+		}
+
+		if p.GoRoutines() != sub1.GoRoutines() {
+			t.Fatalf("TestSubPool: pool and sub1 did not have the same number of goroutines")
+		}
+
+		if p.GoRoutines() != sub2.GoRoutines() {
+			t.Fatalf("TestSubPool: pool and sub2 did not have the same number of goroutines")
+		}
+
+		if p.StaticPool() != sub1.StaticPool() {
+			t.Fatal("TestSubPool: pool and sub1 did not have the same number of static pool goroutines")
+		}
+		if p.StaticPool() != sub2.StaticPool() {
+			t.Fatal("TestSubPool: pool and sub2 did not have the same number of static pool goroutines")
+		}
+
+		sub2.Close(ctx)
+
+		at := atomic.Int64{}
+		sub1.Submit(
+			ctx,
+			func() {
+				at.Add(1)
+			},
+		)
+		p.Submit(
+			ctx,
+			func() {
+				at.Add(1)
+			},
+		)
+		sub1.Wait()
+		p.Wait()
+		if at.Load() != 2 {
+			t.Fatal("TestSubPool: closing sub2 did something bad")
+		}
+	})
 }
 
 func TestRunningZeroAfterWait(t *testing.T) {
@@ -203,46 +195,46 @@ func TestRunningZeroAfterWait(t *testing.T) {
 }
 
 func TestSubPoolDoesNotInflateGoRoutines(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		size := 4
+		p, err := New(ctx, "inflateTest", WithSize(size))
+		if err != nil {
+			t.Fatalf("TestSubPoolDoesNotInflateGoRoutines: got err == %s, want err == nil", err)
+		}
+		defer p.Close(ctx)
 
-	ctx := t.Context()
-	size := 4
-	p, err := New(ctx, "inflateTest", WithSize(size))
-	if err != nil {
-		t.Fatalf("TestSubPoolDoesNotInflateGoRoutines: got err == %s, want err == nil", err)
-	}
-	defer p.Close(ctx)
+		// After creation, the pool should have exactly `size` goroutines. Wait for the static
+		// runners to start and durably block on the queue before reading the baseline.
+		synctest.Wait()
+		baseline := p.GoRoutines()
 
-	// After creation, the pool should have exactly `size` goroutines.
-	// Give runners a moment to start.
-	time.Sleep(100 * time.Millisecond)
-	baseline := p.GoRoutines()
+		// Create multiple sub pools. Each Sub() call should NOT inflate the counter.
+		sub1 := p.Sub(ctx, "sub1")
+		sub2 := p.Sub(ctx, "sub2")
+		sub3 := p.Sub(ctx, "sub3")
 
-	// Create multiple sub pools. Each Sub() call should NOT inflate the counter.
-	sub1 := p.Sub(ctx, "sub1")
-	sub2 := p.Sub(ctx, "sub2")
-	sub3 := p.Sub(ctx, "sub3")
+		afterSubs := p.GoRoutines()
 
-	afterSubs := p.GoRoutines()
+		// The bug: each Sub() adds p.opts.size to the shared goRoutines counter,
+		// so after 3 Sub() calls the counter is inflated by 3 * size.
+		// The correct behavior is that Sub() should not change the counter at all
+		// since no new goroutines are created.
+		if afterSubs != baseline {
+			t.Errorf("TestSubPoolDoesNotInflateGoRoutines: GoRoutines() changed after Sub() calls: baseline %d, after 3 Sub() calls %d (inflated by %d)", baseline, afterSubs, afterSubs-baseline)
+		}
 
-	// The bug: each Sub() adds p.opts.size to the shared goRoutines counter,
-	// so after 3 Sub() calls the counter is inflated by 3 * size.
-	// The correct behavior is that Sub() should not change the counter at all
-	// since no new goroutines are created.
-	if afterSubs != baseline {
-		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: GoRoutines() changed after Sub() calls: baseline %d, after 3 Sub() calls %d (inflated by %d)", baseline, afterSubs, afterSubs-baseline)
-	}
-
-	// Verify the subs share the same counter value.
-	if sub1.GoRoutines() != p.GoRoutines() {
-		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub1 and parent have different GoRoutines()")
-	}
-	if sub2.GoRoutines() != p.GoRoutines() {
-		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub2 and parent have different GoRoutines()")
-	}
-	if sub3.GoRoutines() != p.GoRoutines() {
-		t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub3 and parent have different GoRoutines()")
-	}
+		// Verify the subs share the same counter value.
+		if sub1.GoRoutines() != p.GoRoutines() {
+			t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub1 and parent have different GoRoutines()")
+		}
+		if sub2.GoRoutines() != p.GoRoutines() {
+			t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub2 and parent have different GoRoutines()")
+		}
+		if sub3.GoRoutines() != p.GoRoutines() {
+			t.Errorf("TestSubPoolDoesNotInflateGoRoutines: sub3 and parent have different GoRoutines()")
+		}
+	})
 }
 
 func TestLimitedPoolWarning(t *testing.T) {
@@ -280,64 +272,69 @@ func TestLimitedPoolWarning(t *testing.T) {
 		originalLogger := log.Default()
 		log.Set(testLogger)
 
-		ctx := t.Context()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := context.Background()
 
-		var p *Pool
-		var err error
-		if test.disableWarn {
-			p, err = New(ctx, "testPool", WithDisableLimitedWarn(true))
-		} else {
-			p, err = New(ctx, "testPool")
-		}
-		if err != nil {
-			t.Errorf("TestLimitedPoolWarning(%s): got err == %s, want err == nil", test.name, err)
-			log.Set(originalLogger)
-			continue
-		}
+			var p *Pool
+			var err error
+			if test.disableWarn {
+				p, err = New(ctx, "testPool", WithDisableLimitedWarn(true))
+			} else {
+				p, err = New(ctx, "testPool")
+			}
+			if err != nil {
+				t.Errorf("TestLimitedPoolWarning(%s): got err == %s, want err == nil", test.name, err)
+				return
+			}
+			defer p.Close(ctx)
 
-		// Create a limited pool with only 1 slot
-		limited := p.Limited(ctx, "limitedPool", 1)
+			// Create a limited pool with only 1 slot
+			limited := p.Limited(ctx, "limitedPool", 1)
 
-		// Track completion
-		firstDone := make(chan struct{})
-		secondDone := make(chan struct{})
+			// Track completion
+			firstDone := make(chan struct{})
+			secondDone := make(chan struct{})
 
-		// Fill the slot with a job that blocks until we release it
-		release := make(chan struct{})
-		limited.Submit(ctx, func() {
-			<-release
-			close(firstDone)
+			// Fill the slot with a job that blocks until we release it
+			release := make(chan struct{})
+			limited.Submit(ctx, func() {
+				<-release
+				close(firstDone)
+			})
+
+			// Submit second job that will have to wait
+			go func() {
+				limited.Submit(ctx, func() {
+					close(secondDone)
+				})
+			}()
+
+			// Let the second submit reach its blocked state (the single slot is taken), then
+			// advance the fake clock past warnTimer so the waiting submit logs its warning (only
+			// when warnings are enabled).
+			synctest.Wait()
+			time.Sleep(warnTimer + time.Millisecond)
+			synctest.Wait()
+
+			// Release the first job
+			close(release)
+
+			// Wait for both jobs to complete
+			<-firstDone
+			<-secondDone
+
+			// Verify warning was or wasn't logged
+			logOutput := buf.String()
+			hasWarning := strings.Contains(logOutput, "waiting more than 30 seconds")
+
+			switch {
+			case test.wantWarn && !hasWarning:
+				t.Errorf("TestLimitedPoolWarning(%s): expected warning in log but got none. Log: %s", test.name, logOutput)
+			case !test.wantWarn && hasWarning:
+				t.Errorf("TestLimitedPoolWarning(%s): expected no warning but got: %s", test.name, logOutput)
+			}
 		})
 
-		// Submit second job that will have to wait
-		go func() {
-			limited.Submit(ctx, func() {
-				close(secondDone)
-			})
-		}()
-
-		// Wait for warning to potentially be logged
-		time.Sleep(100 * time.Millisecond)
-
-		// Release the first job
-		close(release)
-
-		// Wait for both jobs to complete
-		<-firstDone
-		<-secondDone
-
-		// Verify warning was or wasn't logged
-		logOutput := buf.String()
-		hasWarning := strings.Contains(logOutput, "waiting more than 30 seconds")
-
-		switch {
-		case test.wantWarn && !hasWarning:
-			t.Errorf("TestLimitedPoolWarning(%s): expected warning in log but got none. Log: %s", test.name, logOutput)
-		case !test.wantWarn && hasWarning:
-			t.Errorf("TestLimitedPoolWarning(%s): expected no warning but got: %s", test.name, logOutput)
-		}
-
-		p.Close(ctx)
 		log.Set(originalLogger)
 	}
 }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to concurrency primitives, especially around background task management, worker pools, and sharded maps. The main themes are: improved handling of canceled contexts (ensuring tasks are not started and errors are reported correctly), enhanced thread safety and iteration capabilities for sharded maps, and additional or improved tests to cover these behaviors and prevent regressions.

**Background task and worker pool improvements:**

* The `WorkerPool` interface's `Submit` method now returns a `bool` indicating whether the job was actually submitted (i.e., the context was not canceled before submission). Callers (`Tasks.Run`, `Tasks.Once`, and `Group`) now check this and return/report errors if the context was canceled, preventing silent failures and potential deadlocks. [[1]](diffhunk://#diff-697666e35e27aec29356768f2f1e1e2ea22fb1571cfe595c59d444ed036d7d81L113-R115) [[2]](diffhunk://#diff-697666e35e27aec29356768f2f1e1e2ea22fb1571cfe595c59d444ed036d7d81R214-R216) [[3]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L20-R22) [[4]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L242-R245) [[5]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L261-R264) [[6]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59R275-R290)
* The `Group` type now properly unwinds wait group accounting and records errors when a job is declined by the pool, preventing deadlocks in `Wait()` if a job is not started due to a canceled context.

**Sharded map thread safety and iteration:**

* Added a new `WithLock` option for `ShardedMap.All()`, which makes iteration over the map thread-safe with respect to concurrent readers and writers by locking each shard during iteration. This is implemented via a new `AllLocked` method in the underlying map. [[1]](diffhunk://#diff-f8a627564bc944c038425a46e4823a0d73e112222d26a5b0c1837803eb440133L69-R100) [[2]](diffhunk://#diff-d2d4e3e28c196d2a7cc6b1674533768b46432a94bf4b09ca04c1a7f1db736135R152-R179)
* Provided clear documentation and safeguards to prevent deadlocks if users attempt to re-enter the same shard during iteration. [[1]](diffhunk://#diff-f8a627564bc944c038425a46e4823a0d73e112222d26a5b0c1837803eb440133L69-R100) [[2]](diffhunk://#diff-d2d4e3e28c196d2a7cc6b1674533768b46432a94bf4b09ca04c1a7f1db736135R152-R179)

**Expanded and improved tests:**

* Added comprehensive tests for background tasks to ensure correct behavior when contexts are already canceled, and for both looping and crashing tasks. [[1]](diffhunk://#diff-a54f97d8b14061af39674d9b9930b111ae76689da5f2145cfaf8752180159084L33-R74) [[2]](diffhunk://#diff-a54f97d8b14061af39674d9b9930b111ae76689da5f2145cfaf8752180159084R194-R241)
* Added regression tests for `Group` to ensure that declined submissions due to canceled contexts do not deadlock `Wait()`, and that errors are reported as expected.
* Added tests for `ShardedMap` to verify that iteration with `WithLock` is thread-safe, that locks are released even on early exit or panic, and that no deadlocks occur.

**Test infrastructure improvements:**

* Introduced a `bubble` helper in tests to ensure background tasks use a test-controlled worker pool and clock, improving determinism and reliability of timing-dependent tests.

These changes significantly improve the robustness, correctness, and test coverage of the concurrency primitives, especially in edge cases involving canceled contexts and concurrent access.

---

**References:**
- [[1]](diffhunk://#diff-697666e35e27aec29356768f2f1e1e2ea22fb1571cfe595c59d444ed036d7d81L113-R115) [[2]](diffhunk://#diff-697666e35e27aec29356768f2f1e1e2ea22fb1571cfe595c59d444ed036d7d81R214-R216) [[3]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L20-R22) [[4]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L242-R245) [[5]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59L261-R264) [[6]](diffhunk://#diff-8ec6a1a9e292995395199dc6b96084f3c7e869ffbf707af9d18897510e88ae59R275-R290) [[7]](diffhunk://#diff-f8a627564bc944c038425a46e4823a0d73e112222d26a5b0c1837803eb440133L69-R100) [[8]](diffhunk://#diff-d2d4e3e28c196d2a7cc6b1674533768b46432a94bf4b09ca04c1a7f1db736135R152-R179) [[9]](diffhunk://#diff-a54f97d8b14061af39674d9b9930b111ae76689da5f2145cfaf8752180159084L33-R74) [[10]](diffhunk://#diff-a54f97d8b14061af39674d9b9930b111ae76689da5f2145cfaf8752180159084R194-R241) [[11]](diffhunk://#diff-7807173f2a21a96fe696580bf2992571546f1a4f641e8269cd3b54192998c994R1-R90) [[12]](diffhunk://#diff-a2b7a0cdb8a457770b26cc79ec9f7a38818908825bbc42a136cc7e24d2e5f1aeR59-R138) [[13]](diffhunk://#diff-a54f97d8b14061af39674d9b9930b111ae76689da5f2145cfaf8752180159084R9-R38)