### PR TITLE
Upgrade retry dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gostdlib/base
 go 1.25.0
 
 require (
-	github.com/Azure/retry v0.0.0-20250701224816-85c6a88f883d
+	github.com/Azure/retry v0.0.0-20260629192600-3a6893b45f6d
 	github.com/CAFxX/httpcompression v0.0.9
 	github.com/beeker1121/goque v2.1.0+incompatible
 	github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSY
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/Azure/retry v0.0.0-20250701224816-85c6a88f883d h1:LkwGxfhHKQwhnJPnTPBccEsc3fyWRhr8uKWo06Uo82E=
-github.com/Azure/retry v0.0.0-20250701224816-85c6a88f883d/go.mod h1:xBDReDRRnjBagqi1R/yGVevV4dE2HAxsuG75AstLY9w=
+github.com/Azure/retry v0.0.0-20260629192600-3a6893b45f6d h1:LDae6A4C5JhqkKaJvx9wFtWdmlfVL7EFhVGJRtfABBs=
+github.com/Azure/retry v0.0.0-20260629192600-3a6893b45f6d/go.mod h1:xQFIQIwXSMk/0NQ+wc/V42PudRntsK0J0ub+5zdBGes=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CAFxX/httpcompression v0.0.9 h1:0ue2X8dOLEpxTm8tt+OdHcgA+gbDge0OqFQWGKSqgrg=


### PR DESCRIPTION
This pull request updates the `github.com/Azure/retry` dependency in the `go.mod` file to a newer version. No other changes are included.

Dependency updates:

* Updated `github.com/Azure/retry` to version `v0.0.0-20260629192600-3a6893b45f6d` in `go.mod` to ensure the project uses the latest features and fixes from this library.