### PR TITLE
Fixes limited and sub pools to use parental limits

### DIFF
--- a/concurrency/worker/limited_test.go
+++ b/concurrency/worker/limited_test.go
@@ -45,6 +45,213 @@ func TestRegressionLimitedCancelRelease(t *testing.T) {
 	})
 }
 
+func TestLimit(t *testing.T) {
+	ctx := context.Background()
+	root, err := New(ctx, "")
+	if err != nil {
+		panic(err)
+	}
+	defer root.Close(ctx)
+
+	tests := []struct {
+		name string
+		pool *Pool
+		want int
+	}{
+		{
+			name: "Success: a root pool is unlimited",
+			pool: root,
+			want: 0,
+		},
+		{
+			name: "Success: Sub of an unlimited pool is unlimited",
+			pool: root.Sub(ctx, ""),
+			want: 0,
+		},
+		{
+			name: "Success: Limited sets the limit",
+			pool: root.Limited(ctx, "", 5),
+			want: 5,
+		},
+		{
+			name: "Success: Sub of a Limited pool inherits the parent limit",
+			pool: root.Limited(ctx, "", 5).Sub(ctx, ""),
+			want: 5,
+		},
+		{
+			name: "Success: Limited smaller than the parent uses the smaller limit",
+			pool: root.Limited(ctx, "", 5).Limited(ctx, "", 3),
+			want: 3,
+		},
+		{
+			name: "Success: Limited larger than the parent is capped to the parent limit",
+			pool: root.Limited(ctx, "", 5).Limited(ctx, "", 10),
+			want: 5,
+		},
+	}
+
+	for _, test := range tests {
+		if got := test.pool.Limit(); got != test.want {
+			t.Errorf("TestLimit(%s): got %d, want %d", test.name, got, test.want)
+		}
+	}
+}
+
+// TestRegressionNestedLimit verifies that a Sub() or Limited() pool derived from a Limited parent is still
+// bounded by the parent's limit. Previously the child dropped the parent's limit and could run unbounded.
+func TestRegressionNestedLimit(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+
+		tests := []struct {
+			name   string
+			derive func(root *Pool) *Pool
+			want   int
+		}{
+			{
+				name:   "Success: Sub of a Limited pool is bounded by the parent limit",
+				derive: func(root *Pool) *Pool { return root.Limited(ctx, "", 2).Sub(ctx, "") },
+				want:   2,
+			},
+			{
+				name:   "Success: Limited larger than the parent is capped to the parent limit",
+				derive: func(root *Pool) *Pool { return root.Limited(ctx, "", 2).Limited(ctx, "", 10) },
+				want:   2,
+			},
+			{
+				name:   "Success: Limited smaller than the parent uses the smaller limit",
+				derive: func(root *Pool) *Pool { return root.Limited(ctx, "", 3).Limited(ctx, "", 1) },
+				want:   1,
+			},
+		}
+
+		for _, test := range tests {
+			root, err := New(ctx, "")
+			if err != nil {
+				panic(err)
+			}
+			assertBound(t, ctx, test.name, test.derive(root), test.want)
+			root.Close(ctx)
+		}
+	})
+}
+
+// TestRegressionNestedLimitSiblingStarvation verifies that a submit blocked on a narrow child limit does not
+// hold a broad parent token and starve a sibling pool. With parent limit 2 and two children each limited to 1,
+// a blocked second submit to child A must not prevent child B from running while only one job is active.
+func TestRegressionNestedLimitSiblingStarvation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		root, err := New(ctx, "")
+		if err != nil {
+			panic(err)
+		}
+		defer root.Close(ctx)
+
+		parent := root.Limited(ctx, "", 2)
+		a := parent.Limited(ctx, "", 1)
+		b := parent.Limited(ctx, "", 1)
+
+		exit := make(chan struct{})
+		var running atomic.Int32
+		block := func() {
+			running.Add(1)
+			<-exit
+			running.Add(-1)
+		}
+
+		// A job runs, holding A's only slot and one of the parent's two slots.
+		aStarted := make(chan struct{})
+		if !a.Submit(ctx, func() { close(aStarted); block() }) {
+			t.Fatalf("TestRegressionNestedLimitSiblingStarvation: A job Submit returned false, want true")
+		}
+		<-aStarted
+
+		// A second A submit cannot run (A is full). It must block on A's semaphore without grabbing a parent
+		// token, otherwise it starves B.
+		go func() {
+			if !a.Submit(ctx, block) {
+				t.Errorf("TestRegressionNestedLimitSiblingStarvation: second A Submit returned false, want true")
+			}
+		}()
+
+		// B must be able to run: only one job is actually running, so a parent slot is free.
+		bRan := make(chan struct{})
+		go func() {
+			if !b.Submit(ctx, func() { close(bRan); block() }) {
+				t.Errorf("TestRegressionNestedLimitSiblingStarvation: B Submit returned false, want true")
+			}
+		}()
+
+		synctest.Wait()
+		select {
+		case <-bRan:
+		default:
+			t.Fatalf("TestRegressionNestedLimitSiblingStarvation: B was starved by a blocked A submit holding a parent token")
+		}
+		if got := running.Load(); got != 2 {
+			t.Fatalf("TestRegressionNestedLimitSiblingStarvation: got %d jobs running, want 2 (A job + B job)", got)
+		}
+
+		// Release everything so the pool drains, including the blocked second A submit.
+		close(exit)
+		synctest.Wait()
+	})
+}
+
+// assertBound verifies that pool l runs at most want jobs concurrently: it saturates l with want blocking
+// jobs, confirms exactly want run while a (want+1)th submit is durably blocked, then releases them and
+// confirms the extra job runs. Must be called inside a synctest bubble.
+func assertBound(t *testing.T, ctx context.Context, name string, l *Pool, want int) {
+	t.Helper()
+
+	exit := make(chan struct{})
+	var running atomic.Int32
+	startedWG := sync.WaitGroup{}
+	startedWG.Add(want)
+	f := func() {
+		running.Add(1)
+		startedWG.Done()
+		<-exit
+		running.Add(-1)
+	}
+
+	// Fill every slot. These submits acquire immediately and must succeed.
+	for i := 0; i < want; i++ {
+		if !l.Submit(ctx, f) {
+			t.Fatalf("TestRegressionNestedLimit(%s): Submit returned false, want true", name)
+		}
+	}
+	startedWG.Wait()
+
+	// One more than the limit: this submit must block acquiring a slot, so its job must not run.
+	extraRan := make(chan struct{})
+	go func() {
+		if !l.Submit(ctx, func() { close(extraRan) }) {
+			t.Errorf("TestRegressionNestedLimit(%s): extra Submit returned false, want true", name)
+		}
+	}()
+
+	synctest.Wait()
+	if got := int(running.Load()); got != want {
+		t.Fatalf("TestRegressionNestedLimit(%s): got %d jobs running concurrently, want %d", name, got, want)
+	}
+	select {
+	case <-extraRan:
+		t.Fatalf("TestRegressionNestedLimit(%s): a job ran beyond the concurrency limit of %d", name, want)
+	default:
+	}
+
+	// Release everything so the extra job can run and the pool drains.
+	close(exit)
+	synctest.Wait()
+	select {
+	case <-extraRan:
+	default:
+		t.Fatalf("TestRegressionNestedLimit(%s): the extra job never ran after slots freed", name)
+	}
+}
+
 func TestLimited(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		exit := make(chan struct{}, 1)

--- a/concurrency/worker/worker.go
+++ b/concurrency/worker/worker.go
@@ -167,7 +167,15 @@ type Pool struct {
 	running    atomic.Int64
 	goRoutines *atomic.Int64
 	metrics    *poolMetrics
-	limit      chan struct{}
+
+	// limits is the chain of semaphores a Submit() must acquire before a job can run, ordered from the
+	// outermost (root-most) Limited ancestor to this pool's own limit. A Sub() or Limited() pool inherits
+	// its ancestors' semaphores so work submitted through a child is still bounded by every parent Limited
+	// pool. Empty means this pool is unlimited.
+	limits []bSync.Semaphore
+	// limitN is the effective concurrency limit for this pool: the smallest capacity in limits. 0 means
+	// unlimited.
+	limitN int
 
 	// child indicates this pool is not a root pool but one that is created with .Sub().
 	child bool
@@ -353,13 +361,19 @@ func (p *Pool) StaticPool() int {
 	return int(p.opts.size)
 }
 
+// Limit returns the maximum number of jobs that can run concurrently in this pool. This is the size set by
+// Limited(), bounded by any parent Limited pool it was derived from. A return of 0 means the pool is unlimited.
+func (p *Pool) Limit() int {
+	return p.limitN
+}
+
 // Submit submits the function to be executed. If the context is canceled before the
 // function is enqueued, the function will not be executed. Once enqueued, the function
 // will run regardless of context cancellation; it is the responsibility of the function
 // to check the context and return if it is canceled. Submit returns true if the function was
 // accepted to run and false if it was declined (the context was canceled before enqueue).
 func (p *Pool) Submit(ctx context.Context, f func()) bool {
-	if p.limit != nil {
+	if len(p.limits) > 0 {
 		return p.limitedSubmit(ctx, f)
 	}
 	return p.submit(ctx, f)
@@ -374,65 +388,98 @@ func (p *Pool) limitedSubmit(ctx context.Context, f func()) bool {
 
 	t := time.Now()
 
-	// Fast-fail an already-cancelled context so we don't needlessly acquire/release a limit
-	// token (the actual no-run guarantee is enforced by submit()).
+	// Fast-fail an already-cancelled context so we don't needlessly acquire/release limit
+	// tokens (the actual no-run guarantee is enforced by submit()).
 	if ctx.Err() != nil {
 		return false
 	}
 
-	// Fast path: try non-blocking acquire to avoid timer allocation in the common case.
-	select {
-	case <-ctx.Done():
-		return false
-	case p.limit <- struct{}{}:
-		goto acquired
-	default:
-	}
-
-	// Slow path: slot is contended, need to wait.
-	if p.opts.disableLimitedWarn {
-		select {
-		case <-ctx.Done():
-			return false
-		case p.limit <- struct{}{}:
-		}
-	} else {
-		for {
-			timer := time.NewTimer(warnTimer)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return false
-			case <-timer.C:
-				name := p.name
-				if name == "" {
-					name = "unnamed"
-				}
-				log.Default().Warn(fmt.Sprintf("worker.Pool(%s): waiting more than 30 seconds to acquire limited pool slot", name))
-				continue
-			case p.limit <- struct{}{}:
+	// Acquire a token from every semaphore in the chain. A nested Limited/Sub pool inherits its ancestors'
+	// semaphores, so this bounds the job by this pool's limit and every parent Limited pool's limit.
+	//
+	// p.limits is ordered root-most first, so we acquire back-to-front: most-specific (narrowest) limit
+	// first, broadest parent last. This ensures a submit that blocks waiting for a slot only holds its own
+	// narrow tokens, never a broad parent token that a sibling pool needs. Acquiring parent-first would let
+	// a submit stalled on a small child limit hog parent capacity and starve siblings.
+	for i := len(p.limits) - 1; i >= 0; i-- {
+		if !p.acquire(ctx, p.limits[i], t) {
+			// Release only the tokens we already acquired (indices i+1..len-1); p.limits[i] was not.
+			for j := i + 1; j < len(p.limits); j++ {
+				p.limits[j].Release()
 			}
-			timer.Stop()
-			break
+			return false
 		}
 	}
-
-acquired:
 
 	spanner.Event(
 		"worker.Pool:Limited.Submit()",
 		attribute.Int64("block_duration_ns", int64(time.Since(t))),
 	)
 
+	// Reaching here means we hold a token in every p.limits semaphore, so releaseAll releases exactly what
+	// we hold. This avoids allocating a per-Submit slice and closure to track the acquired set.
 	wrap := func() {
 		f()
-		<-p.limit
+		p.releaseAll()
 	}
 	if !p.submit(ctx, wrap) {
-		<-p.limit // Release the token since wrap() will never run.
+		p.releaseAll() // Release the tokens since wrap() will never run.
 		return false
 	}
 	return true
+}
+
+// releaseAll releases one token to every semaphore in p.limits. It must be called only on the limitedSubmit
+// success path, where a token is held in each of them.
+func (p *Pool) releaseAll() {
+	for i := 0; i < len(p.limits); i++ {
+		p.limits[i].Release()
+	}
+}
+
+// logName returns p.name for use in log messages, or "unnamed" if the pool has no name.
+func (p *Pool) logName() string {
+	if p.name == "" {
+		return "unnamed"
+	}
+	return p.name
+}
+
+// acquire blocks until a token is acquired from lim or ctx is cancelled, returning true if a token was
+// acquired. start is when the enclosing Submit began waiting; unless disableLimitedWarn is set, acquire logs a
+// warning at each warnTimer boundary of that total wait, so a submit blocked across several semaphores in the
+// chain warns on its cumulative wait rather than resetting the clock per semaphore. Each warning reports the
+// total time waited so far.
+func (p *Pool) acquire(ctx context.Context, lim bSync.Semaphore, start time.Time) bool {
+	// Fast path: try non-blocking acquire to avoid timer allocation in the common case.
+	if ctx.Err() != nil {
+		return false
+	}
+	if lim.TryAcquire() {
+		return true
+	}
+
+	// Slow path: slot is contended, need to wait.
+	if p.opts.disableLimitedWarn {
+		return lim.AcquireContext(ctx)
+	}
+
+	for {
+		// Wait until the next warnTimer boundary of total wait since start. A timeout (ctx still live) means
+		// the submit has crossed another warnTimer of cumulative wait, so we warn and keep waiting; a
+		// cancelled ctx means give up.
+		next := warnTimer - time.Since(start)%warnTimer
+		tctx, cancel := context.WithTimeout(ctx, next)
+		acquired := lim.AcquireContext(tctx)
+		cancel()
+		if acquired {
+			return true
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		log.Default().Warn(fmt.Sprintf("worker.Pool(%s): waited %v for a limited pool slot", p.logName(), time.Since(start).Round(time.Second)))
+	}
 }
 
 // submit submits the function to be executed. If the context is canceled before the
@@ -506,13 +553,28 @@ func init() {
 // If the size is less than 1, it will be set to GOMAXPROCS if that value is less than NumCPU. Otherwise
 // NumCPU will be used. If name is not empty, it will be used for its own metrics. The Limited pool will share
 // the same underlying queue and goroutines as the parent Pool, but will limit the number of concurrent
-// goroutines that can execute at the same time.
+// goroutines that can execute at the same time. If the parent is itself a Limited pool, the new pool is also
+// bounded by the parent's limit; if the requested size exceeds the parent's limit, a warning is logged and the
+// parent's limit is used.
 func (p *Pool) Limited(ctx context.Context, name string, size int) *Pool {
 	if size < 1 {
 		size = numCPU
 	}
-	s := p.Sub(ctx, name)
-	s.limit = make(chan struct{}, size)
+	s := p.Sub(ctx, name) // Inherits the parent's limits chain and limitN.
+
+	// A Limited pool derived from a Limited parent is bounded by the parent. If the requested size is larger
+	// than the parent's limit, the parent's limit is the real ceiling, so we warn and adopt it rather than
+	// adding a wider semaphore that could never bind.
+	if p.limitN > 0 && size > p.limitN {
+		log.Default().Warn(fmt.Sprintf("worker.Pool(%s): Limited() size %d exceeds parent limit %d; using parent limit %d", s.logName(), size, p.limitN, p.limitN))
+		return s
+	}
+
+	sem := bSync.NewSemaphore(size)
+	limits := make([]bSync.Semaphore, len(p.limits), len(p.limits)+1)
+	copy(limits, p.limits)
+	s.limits = append(limits, sem)
+	s.limitN = size
 	return s
 }
 
@@ -553,6 +615,10 @@ func (p *Pool) Sub(ctx context.Context, name string) *Pool {
 		wg:         sync.WaitGroup{},
 		goRoutines: p.goRoutines,
 		child:      true,
+		// Inherit the parent's limit chain so a Sub() of a Limited pool stays bounded by the parent's
+		// limit. Limited() may extend this chain with its own semaphore.
+		limits: p.limits,
+		limitN: p.limitN,
 	}
 
 	return pool

--- a/concurrency/worker/worker_test.go
+++ b/concurrency/worker/worker_test.go
@@ -162,7 +162,7 @@ func TestSubPool(t *testing.T) {
 
 // TestSubPoolName is a regression test for Sub() dropping the pool name. Because Sub() built the
 // child pool without copying name, every Sub()/Limited() pool reported as "unnamed" in the
-// "waiting more than 30 seconds to acquire limited pool slot" warning (see limitedSubmit), making
+// "waited <duration> for a limited pool slot" warning (see limitedSubmit), making
 // it impossible to tell which limited pool was starving.
 func TestSubPoolName(t *testing.T) {
 	ctx := context.Background()
@@ -354,7 +354,7 @@ func TestLimitedPoolWarning(t *testing.T) {
 
 			// Verify warning was or wasn't logged
 			logOutput := buf.String()
-			hasWarning := strings.Contains(logOutput, "waiting more than 30 seconds")
+			hasWarning := strings.Contains(logOutput, "for a limited pool slot")
 
 			switch {
 			case test.wantWarn && !hasWarning:

--- a/context/context.go
+++ b/context/context.go
@@ -278,6 +278,14 @@ func Pool(ctx Context) *worker.Pool {
 	return p
 }
 
+// SetPool sets a custom pool on the returned Context. Pool() calls using this Context use that Pool.
+func SetPool(ctx Context, p *worker.Pool) Context {
+	if p == nil {
+		panic("cannot call SetPool() with nil Pool")
+	}
+	return WithValue(ctx, poolKey{}, p)
+}
+
 // Tasks returns a background.Tasks attached to the context. If not tasks are attached,
 // it returns background.Default().
 func Tasks(ctx Context) *background.Tasks {


### PR DESCRIPTION
This pull request refactors the worker pool concurrency limiting logic to support nested limits and prevent starvation between sibling pools. It introduces a chain of semaphores to enforce limits at all ancestor levels, ensures child pools inherit parent limits, and improves the warning and test logic for these scenarios. The main changes are as follows:

### Concurrency limiting and inheritance improvements

* Refactored the pool limiting mechanism to use a slice of semaphores (`limits`) instead of a single channel, so that each pool is bounded by its own and all ancestor limits. Added `limitN` to track the effective concurrency limit. (`concurrency/worker/worker.go`)
* Updated the `Limited()` and `Sub()` methods so that child pools inherit the parent's limit chain, and a child cannot exceed the parent's limit. If a child requests a higher limit than its parent, it is capped and a warning is logged. (`concurrency/worker/worker.go`) [[1]](diffhunk://#diff-b6211ea8e1dd2b56c676cc6dcfb763d4219bacc682d7c6b16214e48addc476adL509-R577) [[2]](diffhunk://#diff-b6211ea8e1dd2b56c676cc6dcfb763d4219bacc682d7c6b16214e48addc476adR618-R621)
* Added a `Limit()` method to the `Pool` struct to return the effective concurrency limit for a pool. (`concurrency/worker/worker.go`)

### Starvation prevention and improved submission logic

* Updated the job submission logic to acquire semaphores from narrowest (child) to broadest (parent), ensuring that blocked jobs do not hold broad parent tokens and starve sibling pools. Added helper methods for acquiring and releasing all tokens and for improved warning logging. (`concurrency/worker/worker.go`)

### Testing and API improvements

* Added comprehensive tests for limit inheritance, nested limits, and sibling starvation scenarios, as well as regression tests for previous issues. (`concurrency/worker/limited_test.go`)
* Improved test and warning messages for clarity, and added a `SetPool()` helper to the context package for easier pool injection. (`concurrency/worker/worker_test.go`, `context/context.go`) [[1]](diffhunk://#diff-57ac946b33a009d03cd80b1b8ccdb92ebb2f25a07ac885cfd683fd620b980bc9L165-R165) [[2]](diffhunk://#diff-57ac946b33a009d03cd80b1b8ccdb92ebb2f25a07ac885cfd683fd620b980bc9L357-R357) [[3]](diffhunk://#diff-65730f0373fb91dd749940cf09daeaf884e5643d665a6c3eb09d54785a6d475eR281-R288)